### PR TITLE
only send Access-Control-Allow-Methods on option calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,11 @@ module.exports = function(param){
       // append each response header if it is present
       if(origin !== false){
         res.header('Access-Control-Allow-Origin', origin); // required
-        res.header('Access-Control-Allow-Methods', methods); // required
+
+        // ONLY ADD THE FOLLOWING ON OPTION CALLS
+        if ('OPTIONS' === req.method) {
+          res.header('Access-Control-Allow-Methods', methods);
+        }
         if(headers && headers.length){
           res.header('Access-Control-Allow-Headers', headers);
         }

--- a/test/cors.js
+++ b/test/cors.js
@@ -88,11 +88,33 @@ describe('cors', function(){
     cors(options)(req, res, next);
   });
 
-  it('no options enables default CORS to all origins and methods', function(done){
+  it('no options enables default CORS to all origins', function(done){
     // arrange
     var req, res, next;
     req = fakeRequest();
     res = fakeResponse();
+    next = function(){
+      // assert
+      res.header('Access-Control-Allow-Origin').should.equal('*');
+      should.not.exist(res.header('Access-Control-Allow-Methods'));
+      done();
+    };
+
+    // act
+    cors()(req, res, next);
+  });
+
+  it('OPTION call with no options enables default CORS to all origins and methods', function(done){
+    // arrange
+    var req, res, next;
+    req = fakeRequest();
+    req.method = 'OPTIONS';
+    res = fakeResponse();
+    res.send = function(code){
+      // assert
+      code.should.equal(204);
+      done();
+    };
     next = function(){
       // assert
       res.header('Access-Control-Allow-Origin').should.equal('*');
@@ -116,7 +138,13 @@ describe('cors', function(){
         maxAge: 123
       };
       req = fakeRequest();
+      req.method = 'OPTIONS';
       res = fakeResponse();
+      res.send = function(code){
+        // assert
+        code.should.equal(204);
+        done();
+      };
       next = function(){
         // assert
         res.header('Access-Control-Allow-Origin').should.equal('example.com');
@@ -217,7 +245,13 @@ describe('cors', function(){
         methods: ['method1', 'method2']
       };
       req = fakeRequest();
+      req.method = 'OPTIONS';
       res = fakeResponse();
+      res.send = function(code){
+        // assert
+        code.should.equal(204);
+        done();
+      };
       next = function(){
         // assert
         res.header('Access-Control-Allow-Methods').should.equal('method1,method2');
@@ -234,7 +268,13 @@ describe('cors', function(){
       options = {
       };
       req = fakeRequest();
+      req.method = 'OPTIONS';
       res = fakeResponse();
+      res.send = function(code){
+        // assert
+        code.should.equal(204);
+        done();
+      };
       next = function(){
         // assert
         res.header('Access-Control-Allow-Methods').should.equal('GET,PUT,POST,DELETE');


### PR DESCRIPTION
When reading the CORS spec I recognized that all those additional headers should only be send on options requests. 

http://www.html5rocks.com/en/tutorials/cors/
