### PR TITLE
Allow the callback to specify the origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,14 +24,6 @@ module.exports = function(param){
     return typeof(originConfig) === 'function';
   }
 
-  function originFromCallbackConfig(originConfig, req) {
-    var origin = req.header('Origin');
-    if(originConfig(origin)) {
-      return origin;
-    }
-    return false;
-  }
-
   // provide connect with a middleware function
   return function(req, res, next){
     req.pause();
@@ -55,7 +47,7 @@ module.exports = function(param){
       if(config.origin === true){
         origin = req.header('Origin'); // if .origin is *true*, reflect the request Origin
       } else if (originConfigIsCallback(config.origin)) {
-        origin = originFromCallbackConfig(config.origin, req);
+        origin = config.origin(req.header('Origin'));
       } else {
         origin = config.origin;
       }

--- a/test/cors.js
+++ b/test/cors.js
@@ -218,25 +218,25 @@ describe('cors', function(){
       cors(options)(req, res, next);
     });
 
-    it('should allow origin when callback returns true', function(done) {
+    it('should set origin to the value returned by the callback', function(done) {
       var req, res, next, options;
       options = {
         origin: function(sentOrigin) {
           sentOrigin.should.equal('request.com');
-          return true;
+          return 'somethingelse.com';
         }
       };
       req = fakeRequest();
       res = fakeResponse();
       next = function(){
-        res.header('Access-Control-Allow-Origin').should.equal('request.com');
+        res.header('Access-Control-Allow-Origin').should.equal('somethingelse.com');
         done();
       };
 
       cors(options)(req, res, next);
     });
 
-    it('should not allow origin when callback returns false', function(done) {
+    it('should disable CORS when callback returns false', function(done) {
       var req, res, next, options;
       options = {
         origin: function(sentOrigin) {
@@ -257,6 +257,7 @@ describe('cors', function(){
 
       cors(options)(req, res, next);
     });
+
     it('can override methods', function(done){
       // arrange
       var req, res, next, options;


### PR DESCRIPTION
When integrating this into my site, I realized it didn't make sense that the config.origin function only return true or false, because the false origin has a different meaning.

So, in this change, I make the method return the origin.

Let me know if this makes sense.
