### PR TITLE
Fix README typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ var whitelist = ['http://example1.com', 'http://example2.com'];
 var corsOptions = {
   origin: function(origin, callback){
     var originIsWhitelisted = whitelist.indexOf(origin) !== -1;
-    cb(null, originIsWhitelisted);
+    callback(null, originIsWhitelisted);
   }
 };
 


### PR DESCRIPTION
Parameter was called `callback`, but `cb` was being called instead. Fixed to call `callback`.
