### PR TITLE
Origin callback should not be overridden

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -166,8 +166,9 @@
               if (err || !origin) {
                 next(err);
               } else {
-                options.origin = origin;
-                cors(options, req, res, next);
+                var corsOptions = Object.create(options);
+                corsOptions.origin = origin;
+                cors(corsOptions, req, res, next);
               }
             });
           } else {


### PR DESCRIPTION
When using a function to validate the `request.headers.origin` we should keep the original callback to check the next requests.
After a valid request, the `options.origin` value has been updated to `true`, and even though the request is invalid, the cors headers have been added.

Follow below a simple example of how to reproduce this issue:

``` javascript
var express = require('express')
  , cors = require('cors')
  , app = express();


var whitelist = ['http://example1.com', 'http://example2.com'];
var corsOptions = {
  origin: function(origin, callback){
    var originIsWhitelisted = whitelist.indexOf(origin) !== -1;
    callback(null, originIsWhitelisted);
  }
};

app.get('/products/:id', cors(corsOptions), function(req, res, next){
  res.json({msg: 'This is CORS-enabled for a whitelisted domain.'});
});

app.use(cors());

app.listen(5000, function(){
  console.log('CORS-enabled web server listening on port 5000');
});
```

```
curl -i -H "Origin: http://edasdaxample1.com" -XGET -H "Content-Type: application/json" http://localhost:5000/products/1
```

HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: application/json
Content-Length: 56
ETag: "-732085550"
Date: Mon, 12 May 2014 20:52:07 GMT
Connection: keep-alive

```
curl -i -H "Origin: http://example1.com" -XGET -H "Content-Type: application/json" http://localhost:5000/products/1
```

HTTP/1.1 200 OK
X-Powered-By: Express
Access-Control-Allow-Origin: http://example1.com
Content-Type: application/json
Content-Length: 56
ETag: "-732085550"
Date: Mon, 12 May 2014 20:52:08 GMT
Connection: keep-alive

```
curl -i -H "Origin: http://invalid-host.com" -XGET -H "Content-Type: application/json" http://localhost:5000/products/1
```

HTTP/1.1 200 OK
X-Powered-By: Express
Access-Control-Allow-Origin: http://invalid-host.com
Content-Type: application/json
Content-Length: 56
ETag: "-732085550"
Date: Mon, 12 May 2014 20:52:09 GMT
Connection: keep-alive
