### PR TITLE
don't miss data events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -142,9 +142,7 @@
     }
 
     return function (req, res, next) {
-      req.pause(); // make sure downstream middleware don't miss any data events
       optionsCallback(req, function (err, options) {
-        req.resume();
         if (err) {
           next(err);
         } else {
@@ -160,9 +158,7 @@
           }
 
           if (originCallback) {
-            req.pause(); // make sure downstream middleware don't miss any data events
             originCallback(req.headers.origin, function (err, origin) {
-              req.resume();
               if (err || !origin) {
                 next(err);
               } else {

--- a/test/issue-6.js
+++ b/test/issue-6.js
@@ -1,0 +1,24 @@
+
+var http = require('http')
+  , cors = require('../lib')
+  , assert = require('assert')
+
+it('should not miss data', function () {
+  var server = http.createServer(function (req, res) {
+    server.close()
+
+    cors()(req, res, function () {
+      process.nextTick(function () {
+        var body = ''
+        req.on('data', function (chunk) {
+          body += chunk
+        })
+        req.on('end', function () {
+          assert.equal(body, 'foo')
+        })
+      })
+    })
+  }).listen(function () {
+    http.request({ method: 'post', host: '127.0.0.1', port: this.address().port }).end('foo')
+  })
+})


### PR DESCRIPTION
As @Floby has described in #6, should `req.pause()` and `req.resume()` not be called.

In node <0.10 these methods is only advisory which make the solution unreliable.

In node >=0.10 streams are paused by default and calling `req.resume()` triggers old mode which starts emitting events.
