### PR TITLE
Removed npm version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   , "bugs": {"url": "https://github.com/troygoode/node-cors/issues"}
   , "main": "./lib/index.js"
   , "engines": {
-      "node": ">=0.10.0",
-      "npm": "^1.4"
+      "node": ">=0.10.0"
   }
   , "dependencies": {}
   , "devDependencies": {


### PR DESCRIPTION
As cors is not using the npm api directly and npm v2.0.0 was just released, I think its better to drop the npm requirement.

Fixes `npm WARN engine cors@2.4.1: wanted: {"node":">=0.10.0","npm":"^1.4"} (current: {"node":"0.10.31","npm":"2.0.0"})` when installing cors with npm 2.0.0
