### PR TITLE
add vary origin header for specifc origins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,16 +11,26 @@
   };
 
   function configureOrigin(options, req) {
-    var origin = options.origin;
+    var origin = options.origin, header;
     if (origin === true) {
       origin = req.headers.origin;
     } else if (!origin) {
       origin = '*';
     }
-    return {
+    header = {
       key: 'Access-Control-Allow-Origin',
       value: origin
     };
+    if (origin !== '*') {
+      return [
+        {
+          key: 'Vary',
+          value: 'Origin'
+        },
+        header
+      ];
+    }
+    return header;
   }
 
   function configureMethods(options) {
@@ -92,12 +102,16 @@
       method = req.method && req.method.toUpperCase && req.method.toUpperCase(),
       applyHeaders = function (headers, res) {
         headers.forEach(function (header) {
-          if (header && header.value) {
-            if (res.set) {
-              res.set(header.key, header.value);
-            } else {
-              // for Express <4
-              res.setHeader(header.key, header.value);
+          if (header) {
+            if (Array.isArray(header)) {
+              return applyHeaders(header, res);
+            } else if (header.value) {
+              if (res.set) {
+                res.set(header.key, header.value);
+              } else {
+                // for Express <4
+                res.setHeader(header.key, header.value);
+              }
             }
           }
         });

--- a/test/cors.js
+++ b/test/cors.js
@@ -208,6 +208,24 @@
         cors(options)(req, res, next);
       });
 
+      it('includes vary origin header for specific origins', function (done) {
+        // arrange
+        var req, res, next, options;
+        options = {
+          origin: 'example.com'
+        };
+        req = fakeRequest();
+        res = fakeResponse();
+        next = function () {
+          // assert
+          res.getHeader('Vary').should.equal('Origin');
+          done();
+        };
+
+        // act
+        cors(options)(req, res, next);
+      });
+
       it('origin defaults to *', function (done) {
         // arrange
         var req, res, next, options;


### PR DESCRIPTION
If the server specifies an origin host rather than "*", then it must
also include Origin in the Vary response header to indicate to clients
that server responses will differ based on the value of the Origin
request header.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Origin
