### PR TITLE
fix strict mode for node version past 0.10

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,7 @@
 
   function middlewareWrapper(o) {
     // if no options were passed in, use the defaults
-    if (!o || typeof o !== 'object') {
+    if (!o || o === true) {
       o = {};
     }
     if (o.origin === undefined) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,7 @@
 
   function middlewareWrapper(o) {
     // if no options were passed in, use the defaults
-    if (!o) {
+    if (!o || typeof o !== 'object') {
       o = {};
     }
     if (o.origin === undefined) {


### PR DESCRIPTION
set param to object when non object passed in to middlewareWrapper to fix issue with strict mode when a primitive value gets passed in to middlewareWrapper and causes this error:

```
/node_modules/cors/lib/index.js:188
o.origin = defaults.origin;
^
TypeError: Cannot assign to read only property 'origin' of true
```