### PR TITLE
bug with handling preflight requests in Internet Explorer 11

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -166,7 +166,7 @@
       if (options.preflightContinue ) {
         next();
       } else {
-        res.statusCode = 204;
+        res.statusCode = 200;
         res.end();
       }
     } else {

--- a/test/cors.js
+++ b/test/cors.js
@@ -63,7 +63,7 @@
       res = fakeResponse();
       res.end = function () {
         // assert
-        res.statusCode.should.equal(204);
+        res.statusCode.should.equal(200);
         done();
       };
       next = function () {
@@ -102,7 +102,7 @@
       res = fakeResponse();
       res.end = function () {
         // assert
-        res.statusCode.should.equal(204);
+        res.statusCode.should.equal(200);
         done();
       };
       next = function () {
@@ -138,7 +138,7 @@
       res = fakeResponse();
       res.end = function () {
         // assert
-        res.statusCode.should.equal(204);
+        res.statusCode.should.equal(200);
         done();
       };
       next = function () {
@@ -168,7 +168,7 @@
         res = fakeResponse();
         res.end = function () {
           // assert
-          res.statusCode.should.equal(204);
+          res.statusCode.should.equal(200);
           done();
         };
         next = function () {
@@ -426,7 +426,7 @@
         res = fakeResponse();
         res.end = function () {
           // assert
-          res.statusCode.should.equal(204);
+          res.statusCode.should.equal(200);
           done();
         };
         next = function () {
@@ -449,7 +449,7 @@
         res = fakeResponse();
         res.end = function () {
           // assert
-          res.statusCode.should.equal(204);
+          res.statusCode.should.equal(200);
           done();
         };
         next = function () {

--- a/test/example-app.js
+++ b/test/example-app.js
@@ -15,7 +15,7 @@
 
   simpleApp = express();
   simpleApp.head('/', cors(), function (req, res) {
-    res.status(204).send();
+    res.status(200).send();
   });
   simpleApp.get('/', cors(), function (req, res) {
     res.send('Hello World (Get)');
@@ -50,7 +50,7 @@
       it('HEAD works', function (done) {
         supertest(simpleApp)
           .head('/')
-          .expect(204)
+          .expect(200)
           .end(function (err, res) {
             should.not.exist(err);
             res.headers['access-control-allow-origin'].should.eql('*');
@@ -74,7 +74,7 @@
       it('OPTIONS works', function (done) {
         supertest(complexApp)
           .options('/')
-          .expect(204)
+          .expect(200)
           .end(function (err, res) {
             should.not.exist(err);
             res.headers['access-control-allow-origin'].should.eql('*');

--- a/test/issue-2.js
+++ b/test/issue-2.js
@@ -31,7 +31,7 @@
     it('OPTIONS works', function (done) {
       supertest(app)
         .options('/api/login')
-        .expect(204)
+        .expect(200)
         .set('Origin', 'http://example.com')
         .end(function (err, res) {
           should.not.exist(err);

--- a/test/issue-31.js
+++ b/test/issue-31.js
@@ -32,7 +32,7 @@
     it('OPTIONS works', function (done) {
       supertest(app)
         .options('/items')
-        .expect(204)
+        .expect(200)
         .set('Origin', 'http://example.com')
         .end(function (err, res) {
           should.not.exist(err);


### PR DESCRIPTION
In case with non-simple CORS, when request has
Content-Type='application/json' or request contains headers, that will
be added to "Access-Control-Request-Headers", IE11 is failed to handle
response with status 204 of "OPTIONS" request.