### PR TITLE
Update README to fix incorrect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ var whitelist = ['http://example1.com', 'http://example2.com'];
 var corsOptions = {
   origin: function(origin, callback){
     var originIsWhitelisted = whitelist.indexOf(origin) !== -1;
-    callback(null, originIsWhitelisted);
+    callback(originIsWhitelisted ? null : 'Bad Request', originIsWhitelisted);
   }
 };
 


### PR DESCRIPTION
I struggled with this example for a few hours, and then realized that the example doesn't return an error in the callback function, which prevents the request from failing properly in the case where there's no whitelist match. I've updated it in the simplest way possible to make it work.