### PR TITLE
fix docs and tests for Access-Control-Max-Age

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ app.listen(80, function(){
 ## Configuration Options
 
 * `origin`: Configures the **Access-Control-Allow-Origin** CORS header. Possible values:
- - `Boolean` - set `origin` to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined by `req.header('Origin')`, or set it to `false` to disable CORS. 
+ - `Boolean` - set `origin` to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined by `req.header('Origin')`, or set it to `false` to disable CORS.
  - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
  - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
  - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
@@ -174,7 +174,7 @@ app.listen(80, function(){
 * `allowedHeaders`: Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Type,Authorization') or an array (ex: `['Content-Type', 'Authorization']`). If not specified, defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header.
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range') or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.
 * `credentials`: Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
-* `maxAge`: Configures the **Access-Control-Allow-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
+* `maxAge`: Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
 * `preflightContinue`: Pass the CORS preflight response to the next handler.
 
 The default configuration is the equivalent of:

--- a/test/cors.js
+++ b/test/cors.js
@@ -177,7 +177,7 @@
           res.getHeader('Access-Control-Allow-Methods').should.equal('FOO,bar');
           res.getHeader('Access-Control-Allow-Headers').should.equal('FIZZ,buzz');
           res.getHeader('Access-Control-Allow-Credentials').should.equal('true');
-          res.getHeader('Access-Control-Allow-Max-Age').should.equal('123');
+          res.getHeader('Access-Control-Max-Age').should.equal('123');
           done();
         };
 
@@ -241,7 +241,7 @@
           should.not.exist(res.getHeader('Access-Control-Allow-Methods'));
           should.not.exist(res.getHeader('Access-Control-Allow-Headers'));
           should.not.exist(res.getHeader('Access-Control-Allow-Credentials'));
-          should.not.exist(res.getHeader('Access-Control-Allow-Max-Age'));
+          should.not.exist(res.getHeader('Access-Control-Max-Age'));
           done();
         };
 
@@ -373,7 +373,7 @@
           should.not.exist(res.getHeader('Access-Control-Allow-Methods'));
           should.not.exist(res.getHeader('Access-Control-Allow-Headers'));
           should.not.exist(res.getHeader('Access-Control-Allow-Credentials'));
-          should.not.exist(res.getHeader('Access-Control-Allow-Max-Age'));
+          should.not.exist(res.getHeader('Access-Control-Max-Age'));
           done();
         };
 
@@ -407,7 +407,7 @@
           should.not.exist(res.getHeader('Access-Control-Allow-Methods'));
           should.not.exist(res.getHeader('Access-Control-Allow-Headers'));
           should.not.exist(res.getHeader('Access-Control-Allow-Credentials'));
-          should.not.exist(res.getHeader('Access-Control-Allow-Max-Age'));
+          should.not.exist(res.getHeader('Access-Control-Max-Age'));
           done();
         };
 
@@ -599,7 +599,7 @@
         res = fakeResponse();
         next = function () {
           // assert
-          should.not.exist(res.getHeader('Access-Control-Allow-Max-Age'));
+          should.not.exist(res.getHeader('Access-Control-Max-Age'));
           done();
         };
 


### PR DESCRIPTION
Code had incorrect header name Access-Control-Allow-Max-Age
in several places

https://www.w3.org/TR/cors/#http-access-control-max-age

Follows through on changes initially from #13