### PR TITLE
Add OPTIONS to the default allow methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The default configuration is the equivalent of:
 ```json
 {
   "origin": "*",
-  "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
+  "methods": "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS",
   "preflightContinue": false
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
 
   var defaults = {
       origin: '*',
-      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
       preflightContinue: false
     };
 

--- a/test/cors.js
+++ b/test/cors.js
@@ -439,7 +439,7 @@
         cors(options)(req, res, next);
       });
 
-      it('methods defaults to GET, PUT, PATCH, POST, DELETE', function (done) {
+      it('methods defaults to GET, PUT, PATCH, POST, DELETE, OPTIONS', function (done) {
         // arrange
         var req, res, next, options;
         options = {
@@ -454,7 +454,7 @@
         };
         next = function () {
           // assert
-          res.getHeader('Access-Control-Allow-Methods').should.equal('GET,PUT,PATCH,POST,DELETE');
+          res.getHeader('Access-Control-Allow-Methods').should.equal('GET,PUT,PATCH,POST,DELETE,OPTIONS');
           done();
         };
 

--- a/test/example-app.js
+++ b/test/example-app.js
@@ -78,6 +78,7 @@
           .end(function (err, res) {
             should.not.exist(err);
             res.headers['access-control-allow-origin'].should.eql('*');
+            res.headers['access-control-allow-methods'].should.match(/(OPTIONS)|\*/);
             done();
           });
       });

--- a/test/example-app.js
+++ b/test/example-app.js
@@ -78,7 +78,7 @@
           .end(function (err, res) {
             should.not.exist(err);
             res.headers['access-control-allow-origin'].should.eql('*');
-            res.headers['access-control-allow-methods'].should.match(/(OPTIONS)|\*/);
+            res.headers['access-control-allow-methods'].should.match(/OPTIONS/);
             done();
           });
       });

--- a/test/issue-2.js
+++ b/test/issue-2.js
@@ -36,7 +36,7 @@
         .end(function (err, res) {
           should.not.exist(err);
           res.headers['access-control-allow-origin'].should.eql('http://example.com');
-          res.headers['access-control-allow-methods'].should.match(/(OPTIONS)|(\*)/);
+          res.headers['access-control-allow-methods'].should.match(/OPTIONS/);
           done();
         });
     });

--- a/test/issue-2.js
+++ b/test/issue-2.js
@@ -16,7 +16,7 @@
   app = express();
   corsOptions = {
     origin: true,
-    methods: ['POST'],
+    methods: ['POST', 'OPTIONS'],
     credentials: true,
     maxAge: 3600
   };
@@ -36,6 +36,7 @@
         .end(function (err, res) {
           should.not.exist(err);
           res.headers['access-control-allow-origin'].should.eql('http://example.com');
+          res.headers['access-control-allow-methods'].should.match(/(OPTIONS)|(\*)/);
           done();
         });
     });

--- a/test/issue-31.js
+++ b/test/issue-31.js
@@ -37,6 +37,7 @@
         .end(function (err, res) {
           should.not.exist(err);
           res.headers['access-control-allow-origin'].should.eql('*');
+          res.headers['access-control-allow-methods'].should.match(/(OPTIONS)|(\*)/);
           done();
         });
     });

--- a/test/issue-31.js
+++ b/test/issue-31.js
@@ -37,7 +37,7 @@
         .end(function (err, res) {
           should.not.exist(err);
           res.headers['access-control-allow-origin'].should.eql('*');
-          res.headers['access-control-allow-methods'].should.match(/(OPTIONS)|(\*)/);
+          res.headers['access-control-allow-methods'].should.match(/OPTIONS/);
           done();
         });
     });


### PR DESCRIPTION
The response's header's access-control-allow-methods to contain OPTIONS when the browser check if it's allowed to access that method. So when in test cases, we should also check the access-control-allow-methods.It seems all test cases should test the access-control-allow-methods contains the methods name.