### PR TITLE
Provide name for currently anonymous middleware function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,7 @@
       };
     }
 
-    return function (req, res, next) {
+    return function corsMiddleware(req, res, next) {
       optionsCallback(req, function (err, options) {
         if (err) {
           next(err);


### PR DESCRIPTION
Hi there!

I'm working on a little tool for debugging middleware stacks in express. Specifically for use whilst refactoring [Ghost](https://github.com/TryGhost/Ghost) but I hope other people will find it useful too.

The middleware function provided by this module is currently anonymous, which makes debugging & inspection a little bit tricky. Adding a name shouldn't have any impact other than making it easier to debug and inspect this middleware.

I have run the tests & linting, and this change (as expected) had no impact.