### PR TITLE
In example: use Error for errors in Node callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,12 @@ var app = express()
 
 var whitelist = ['http://example1.com', 'http://example2.com']
 var corsOptions = {
-  origin: function (origin, callback) {
-    var originIsWhitelisted = whitelist.indexOf(origin) !== -1
-    callback(originIsWhitelisted ? null : new Error('Bad Request'), originIsWhitelisted)
+  origin: function (origin, cb) {
+    if (whitelist.includes(origin)) {
+      cb(null, true)
+    } else {
+      cb(new Error('Not allowed by CORS'))
+    }
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ var whitelist = ['http://example1.com', 'http://example2.com']
 var corsOptions = {
   origin: function (origin, callback) {
     var originIsWhitelisted = whitelist.indexOf(origin) !== -1
-    callback(originIsWhitelisted ? null : 'Bad Request', originIsWhitelisted)
+    callback(originIsWhitelisted ? null : new Error('Bad Request'), originIsWhitelisted)
   }
 }
 


### PR DESCRIPTION
An example passes back a string if there is an error instead of an `Error`. This fixes the example.

(This also contradicts the docs, which mentions that the first parameter of the callback is an `err [object]`.)

We had someone copy and paste from your example, and it messed with one of our express error handlers that was (reasonably) expecting an error, so I figured I'd update the docs for posterity's sake.