### PR TITLE
Copy `options` object before altering it

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
   'use strict';
 
   var vary = require('vary');
+  var assign = Object.assign || require('object-assign');
 
   var defaults = {
       origin: '*',
@@ -72,7 +73,7 @@
   }
 
   function configureMethods(options) {
-    var methods = options.methods || defaults.methods;
+    var methods = options.methods;
     if (methods.join) {
       methods = options.methods.join(','); // .methods is an array, so turn it into a string
     }
@@ -181,18 +182,9 @@
   }
 
   function middlewareWrapper(o) {
+    if (typeof o !== 'function') {
     // if no options were passed in, use the defaults
-    if (!o || o === true) {
-      o = {};
-    }
-    if (o.origin === undefined) {
-      o.origin = defaults.origin;
-    }
-    if (o.methods === undefined) {
-      o.methods = defaults.methods;
-    }
-    if (o.preflightContinue === undefined) {
-      o.preflightContinue = defaults.preflightContinue;
+      o = assign({}, defaults, o);
     }
 
     // if options are static (either via defaults or custom options passed in), wrap in a function

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,7 +183,6 @@
 
   function middlewareWrapper(o) {
     if (typeof o !== 'function') {
-    // if no options were passed in, use the defaults
       o = assign({}, defaults, o);
     }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "2.8.1",
   "author": "Troy Goode <troygoode@gmail.com> (https://github.com/troygoode/)",
   "description": "middleware for dynamically or statically enabling CORS in express/connect applications",
-  "keywords": ["cors", "express", "connect", "middleware"],
+  "keywords": [
+    "cors",
+    "express",
+    "connect",
+    "middleware"
+  ],
   "homepage": "https://github.com/expressjs/cors/",
   "repository": {
     "type": "git",
@@ -17,12 +22,15 @@
     }
   ],
   "license": "MIT",
-  "bugs": {"url": "https://github.com/expressjs/cors/issues"},
+  "bugs": {
+    "url": "https://github.com/expressjs/cors/issues"
+  },
   "main": "./lib/index.js",
   "engines": {
     "node": ">=0.10.0"
   },
   "dependencies": {
+    "object-assign": "^4.1.1",
     "vary": "^1"
   },
   "devDependencies": {

--- a/test/cors.js
+++ b/test/cors.js
@@ -44,8 +44,8 @@
   describe('cors', function () {
     it('does not alter `options` configuration object', function () {
       var options = Object.freeze({
-          origin: 'custom-origin'
-        });
+        origin: 'custom-origin'
+      });
       (function () {
         cors(options);
       }).should.not.throw();

--- a/test/cors.js
+++ b/test/cors.js
@@ -42,6 +42,15 @@
     };
 
   describe('cors', function () {
+    it('does not alter `options` configuration object', function () {
+      var options = Object.freeze({
+          origin: 'custom-origin'
+        });
+      (function () {
+        cors(options);
+      }).should.not.throw();
+    });
+
     it('passes control to next middleware', function (done) {
       // arrange
       var req, res, next;


### PR DESCRIPTION
Fixes #99.

Added dependency (needed for node 0.10 and 0.12 support only): object-assign ([npm](https://www.npmjs.com/package/object-assign) - [github](https://github.com/sindresorhus/object-assign)).

Tests pass locally on my machine with node 0.10, 0.12.9, 4.3.0 and node 6 (didn't try other versions).