### PR TITLE
Send “Vary: Origin” when Origin is not whitelisted 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,12 +60,10 @@
         key: 'Access-Control-Allow-Origin',
         value: isAllowed ? requestOrigin : false
       }]);
-      if (isAllowed) {
-        headers.push([{
-          key: 'Vary',
-          value: 'Origin'
-        }]);
-      }
+      headers.push([{
+        key: 'Vary',
+        value: 'Origin'
+      }]);
     }
 
     return headers;

--- a/test/cors.js
+++ b/test/cors.js
@@ -238,7 +238,7 @@
         cors(options)(req, res, function(err) {
           should.not.exist(err);
           should.not.exist(res.getHeader('Access-Control-Allow-Origin'));
-          should.not.exist(res.getHeader('Vary'));
+          should.exist(res.getHeader('Vary'));
           return done();
         });
       });


### PR DESCRIPTION
When using the 'array' or 'regexp' notation of whitelisted origins we don't send 'Vary: Origin' if the passed Origin is not allowed.

This results in failed CORS responses being cached by the downstream cache and subsequently served even for proper request (which would contain Vary: Origin, but downstream won't fetch them, as it has the cached response it's looking for). 

This behavior is seen with e.g. Google Cloud cache, with the additional side effect of a failed CORS response overwriting all the previously cached successful responses that contained "Vary: Origin".