### PR TITLE
Examples of how to add OPTIONS handlers at the router level

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ You can also enable pre-flight across-the-board like so:
 app.options('*', cors()) // include before other routes
 ```
 
+Or at the router level in one of these ways:
+
+```js
+// Option 1: cors used inside router.js
+var express = require('express');
+var router = express.Router();
+
+router.use(cors());
+
+router.del('/products/:id', function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for all origins!'})
+});
+
+module.exports = router;
+
+
+// Option 2: CORS not used inside router.js
+app.use('/api', cors(), require('./router'));
+```
+
 ### Configuring CORS Asynchronously
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Or at the router level in one of these ways:
 ```js
 // Option 1: cors used inside router.js
 var express = require('express');
+var cors = require('cors');
 var router = express.Router();
 
 router.use(cors());


### PR DESCRIPTION
This works because cors internally handles OPTIONS requests
https://github.com/expressjs/cors/blob/075c4b51452542f52ad21898ec781f725c84934d/lib/index.js#L163
and so doesn’t strictly need express to route OPTIONS requests to it
(using `app.options`) as the documentation suggested prior to this commit.