### PR TITLE
Shortcircuit responses to invalid origins when configured with `mismatchContinue: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ app.listen(80, function () {
 
 ### CORS and CSRF
 
-The default configuration of this module implements the CORS specification as outlined by the W3C. That specification is not designed to prevent servers from responding to requests, but rather to allow clients to make cross-origin requests. Thus, in the case of a CORS "failure", where the request's origin is not allowed, the browser will refuse to deliver the response _after_ the server responds as if the request had been valid.
+The default configuration of this module implements the CORS specification as outlined by the W3C. That specification is designed to allow clients to make cross-origin requests, not to prevent servers from responding to requests. Thus, in the case of a CORS "failure", where the request's origin is not allowed, the browser will refuse to deliver the response _after_ the server responds as if the request had been valid.
 
 Thus, CORS is not a defense against [CSRF](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)): even if cross-origin rules prevent the attacker from seeing the response to the forged request, the attacker can modify state or force the server to perform some expensive calculation, thus causing a denial of service.
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,37 @@ app.listen(80, function () {
 })
 ```
 
+### CORS and CSRF
+
+The default configuration of this module implements the CORS specification as outlined by the W3C. That specification is not designed to prevent servers from responding to requests, but rather to allow clients to make cross-origin requests. Thus, in the case of a CORS "failure", where the request's origin is not allowed, the browser will refuse to deliver the response _after_ the server responds as if the request had been valid.
+
+Thus, CORS is not a defense against [CSRF](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)): even if cross-origin rules prevent the attacker from seeing the response to the forged request, the attacker can modify state or force the server to perform some expensive calculation, thus causing a denial of service.
+
+However, this module can be configured to short-circuit the request in case of CORS failures, thus implementing basic CSRF protection [as recommended by the OWASP](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Checking_the_Origin_Header). To do this, configure this module with `mismatchContinue: false`:
+
+```js
+var express = require('express');
+var cors = require('cors');
+var app = express();
+
+// `mismatchContinue: false` will work with any of the `origin` options supported
+// by this module. However it won't help prevent CSRF unless you whitelist specific
+// origins. Also see caveats below!
+var whitelist = ['https://same-origin.com', 'https://other-origin.com'];
+
+app.del('/products/:id', cors({ origin: whitelist, mismatchContinue: false }), function (req, res, next) {
+  res.json({msg: 'This will not be executed if called from https://evil-origin.com.'});
+});
+
+app.listen(80, function () {
+  console.log('CORS-enabled and CSRF-protected web server listening on port 80');
+});
+```
+
+Make sure to whitelist cross-origin AND same-origin requests, since the middleware will reject any request whose origin is not on the list. This also means that the middleware will reject requests with _missing_ origins. This means that `mismatchContinue: false` is NOT SUITED for routes where the `Origin` header may be missing, e.g. routes loaded directly by users in the browser, or routes loaded by `<img>` tags. However AJAX requests should [always have `Origin` headers](https://bugs.chromium.org/p/chromium/issues/detail?id=512836#c3).
+
+If you don't want to enable a route for cross-origin usage but you _do_ wish to verify same-origin usage, you can apply this module to that route with _only_ the same origin whitelisted.
+
 ## Configuration Options
 
 * `origin`: Configures the **Access-Control-Allow-Origin** CORS header. Possible values:
@@ -179,7 +210,7 @@ app.listen(80, function () {
   - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
   - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
   - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
-  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback (which expects the signature `err [object], allow [bool]`) as the second.
+  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback (which expects the signature `err [object], allow [bool]`) as the second. If the function calls back with `allow === false`, CORS will not be enabled for the response, but the next handler will still run unless `mismatchContinue === false`.
 * `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).
 * `allowedHeaders`: Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Type,Authorization') or an array (ex: `['Content-Type', 'Authorization']`). If not specified, defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header.
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range') or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.
@@ -187,6 +218,8 @@ app.listen(80, function () {
 * `maxAge`: Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
 * `preflightContinue`: Pass the CORS preflight response to the next handler.
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
+* `mismatchContinue`: `true` to call the next handler even if `req.headers.origin` is missing or doesn't match `origin`, `false` to end the request with `mismatchStatus`.
+* `mismatchStatus`: Provides a status code to use for requests with missing or invalid `Origin` headers when `mismatchContinue === false`. Defaults to 400.
 
 The default configuration is the equivalent of:
 
@@ -195,7 +228,9 @@ The default configuration is the equivalent of:
   "origin": "*",
   "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
   "preflightContinue": false,
-  "optionsSuccessStatus": 204
+  "optionsSuccessStatus": 204,
+  "mismatchContinue": true,
+  "mismatchStatus": 400
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,11 @@
       origin: '*',
       methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
       preflightContinue: false,
-      optionsSuccessStatus: 204
+      optionsSuccessStatus: 204,
+      mismatchContinue: true,
+      // 400 chosen because https://httpstatuses.com/400 says it can be used
+        // for "deceptive request routing".
+      mismatchStatus: 400
     };
 
   function isString(s) {
@@ -211,14 +215,31 @@
             originCallback = options.origin;
           } else if (options.origin) {
             originCallback = function (origin, cb) {
-              cb(null, options.origin);
+              var isAllowed = (!options.origin || options.origin === '*' ||
+                isOriginAllowed(origin, options.origin));
+              // When a user-specified handler returns `false`, we skip applying
+              // the CORS headers and run the request handler (see below). But
+              // the default handler should apply the headers even in case of
+              // a mismatch unless `mismatchContinue === false`.
+              if (isAllowed || (options.mismatchContinue !== false)) {
+                cb(null, options.origin);
+              } else {
+                cb(null, false);
+              }
             };
           }
 
           if (originCallback) {
             originCallback(req.headers.origin, function (err2, origin) {
-              if (err2 || !origin) {
+              if (err2) {
                 next(err2);
+              } else if (!origin) {
+                if (options.mismatchContinue === false) {
+                  res.statusCode = options.mismatchStatus || defaults.mismatchStatus;
+                  res.end();
+                } else {
+                  next();
+                }
               } else {
                 var corsOptions = Object.create(options);
                 corsOptions.origin = origin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
       optionsSuccessStatus: 204,
       mismatchContinue: true,
       // 400 chosen because https://httpstatuses.com/400 says it can be used
-        // for "deceptive request routing".
+      // for "deceptive request routing".
       mismatchStatus: 400
     };
 

--- a/test/reject-mismatches.js
+++ b/test/reject-mismatches.js
@@ -1,0 +1,247 @@
+(function () {
+  /*global describe, it*/
+
+  'use strict';
+
+  var cors = require('../lib');
+
+  var fakeRequest = function (headers) {
+      return {
+        headers: headers || {
+          'origin': 'http://www.request.com'
+        },
+        pause: function () {
+          // do nothing
+          return;
+        },
+        resume: function () {
+          // do nothing
+          return;
+        }
+      };
+    },
+    fakeResponse = function () {
+      var headers = {};
+      return {
+        allHeaders: function () {
+          return headers;
+        },
+        getHeader: function (key) {
+          return headers[key];
+        },
+        setHeader: function (key, value) {
+          headers[key] = value;
+          return;
+        },
+        get: function (key) {
+          return headers[key];
+        }
+      };
+    };
+
+  describe('mismatchContinue', function () {
+    it('doesn\'t shortcircuit requests with missing origins by default', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest({});
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        done('should not be called');
+      };
+      next = function () {
+        // assert
+        done();
+      };
+
+      // act
+      cors()(req, res, next);
+    });
+
+    it('doesn\'t shortcircuit requests with mismatching origins by default', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest();
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        done('should not be called');
+      };
+      next = function () {
+        // assert
+        done();
+      };
+
+      // act
+      cors({
+        origin: 'http://example.com'
+      })(req, res, next);
+    });
+
+    it('shortcircuits requests with missing origins with `mismatchContinue: false`', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest({});
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        res.statusCode.should.equal(400);
+        done();
+      };
+      next = function () {
+        // assert
+        done('should not be called');
+      };
+
+      // act
+      cors({
+        origin: 'http://example.com',
+        mismatchContinue: false
+      })(req, res, next);
+    });
+
+    it('shortcircuits requests with mismatching origins with `mismatchContinue: false`', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest();
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        res.statusCode.should.equal(400);
+        done();
+      };
+      next = function () {
+        // assert
+        done('should not be called');
+      };
+
+      // act
+      cors({
+        origin: 'http://example.com',
+        mismatchContinue: false
+      })(req, res, next);
+    });
+
+    it('can configure mismatch response status code', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest();
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        res.statusCode.should.equal(401);
+        done();
+      };
+      next = function () {
+        // assert
+        done('should not be called');
+      };
+
+      // act
+      cors({
+        origin: 'http://example.com',
+        mismatchContinue: false,
+        mismatchStatus: 401
+      })(req, res, next);
+    });
+
+    it('matches request origin against regexp', function(done) {
+      var req = fakeRequest();
+      var res = fakeResponse();
+      var options = {
+        origin: /^(.+\.)?request.com$/,
+        mismatchContinue: false
+      };
+
+      res.end = function () {
+        // assert
+        done('should not be called');
+      };
+      var next = function () {
+        // assert
+        done();
+      };
+
+      // act
+      cors(options)(req, res, next);
+    });
+
+    it('matches request origin against array of origin checks', function(done) {
+      var req = fakeRequest();
+      var res = fakeResponse();
+      var options = { origin: [ /foo\.com$/, 'request.com' ] };
+      res.end = function () {
+        // assert
+        done('should not be called');
+      };
+      var next = function () {
+        // assert
+        done();
+      };
+
+      // act
+      cors(options)(req, res, next);
+    });
+
+    it('doesn\'t match request origin against array of invalid origin checks', function(done) {
+      var req = fakeRequest();
+      var res = fakeResponse();
+      var options = {
+        origin: [ /foo\.com$/, 'bar.com' ],
+        mismatchContinue: false
+      };
+      res.end = function () {
+        // assert
+        res.statusCode.should.equal(400);
+        done();
+      };
+      var next = function () {
+        // assert
+        done('should not be called');
+      };
+      cors(options)(req, res, next);
+    });
+
+    it('should not shortcircuit when callback returns true', function (done) {
+      var req, res, next, options;
+      options = {
+        origin: function (sentOrigin, cb) {
+          cb(null, true);
+        },
+        mismatchContinue: false
+      };
+      req = fakeRequest();
+      res = fakeResponse();
+      next = function () {
+        done();
+      };
+
+      cors(options)(req, res, next);
+    });
+
+    it('should shortcircuit when callback returns false', function (done) {
+      var req, res, next, options;
+      options = {
+        origin: function (sentOrigin, cb) {
+          cb(null, false);
+        },
+        mismatchContinue: false
+      };
+      req = fakeRequest();
+      res = fakeResponse();
+
+      res.end = function () {
+        // assert
+        res.statusCode.should.equal(400);
+        done();
+      };
+      next = function () {
+        // assert
+        done('should not be called');
+      };
+
+      cors(options)(req, res, next);
+    });
+  });
+
+}());


### PR DESCRIPTION
This option enables this module to be used for basic CSRF protection as
recommended by the OWASP: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Checking_the_Origin_Header,
while remaining strictly compatible with the CORS specification by default.

When `mismatchComplete === false` and a request's origin header is either
missing or not allowed, per the module's configuration, the middleware will
terminate the request rather than execute the next handler. If
`mismatchComplete` is any other value, the middleware will execute the next
handler as before.

When the middleware terminates the request, it does so with a 400 by default
since https://httpstatuses.com/400 says that can be used for "deceptive
request routing"; this status code is configurable with `mismatchStatus`.

Fixes https://github.com/expressjs/cors/issues/109.