### PR TITLE
fixes #120 - content length zero for 204 response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,9 @@
         next();
       } else {
         res.statusCode = options.optionsSuccessStatus || defaults.optionsSuccessStatus;
+        // Safari (and potentially other browsers) need content-length 0,
+        //   besides 204 or they just hang waiting for a body
+        res.setHeader('Content-Length', '0');
         res.end();
       }
     } else {

--- a/test/cors.js
+++ b/test/cors.js
@@ -143,6 +143,26 @@
       cors()(req, res, next);
     });
 
+    it('includes Content-Length response header', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest();
+      req.method = 'options';
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        res.getHeader('Content-Length').should.equal('0');
+        done();
+      };
+      next = function () {
+        // assert
+        done('should not be called');
+      };
+
+      // act
+      cors()(req, res, next);
+    });
+
     it('no options enables default CORS to all origins', function (done) {
       // arrange
       var req, res, next;


### PR DESCRIPTION
Safari apparently hangs waiting for the body when OPTIONS response is
204, content-length: 0 fixes that behavior.