### PR TITLE
docs: improve readability on if-else statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ var corsOptionsDelegate = function (req, callback) {
   var corsOptions;
   if (whitelist.indexOf(req.header('Origin')) !== -1) {
     corsOptions = { origin: true } // reflect (enable) the requested origin in the CORS response
-  }else{
+  } else {
     corsOptions = { origin: false } // disable CORS for this request
   }
   callback(null, corsOptions) // callback expects two parameters: error and options


### PR DESCRIPTION
On the example for Configuring CORS Async, the `else` keyword has no spaces between itself and the curly braces. This improves the readibility of the statement and uses the same spacing as used in the example for Configuring CORS w/ Dynamic Origin.