### PR TITLE
Added help text for cases where origin is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ app.listen(80, function () {
 })
 ```
 
+If you do not want to block REST tools or server-to-server requests,
+add a `!origin` check in the origin function like so:
+
+```javascript
+var corsOptions = {
+  origin: function (origin, callback) {
+    if (whitelist.indexOf(origin) !== -1 || !origin) {
+      callback(null, true)
+    } else {
+      callback(new Error('Not allowed by CORS'))
+    }
+  }
+}
+```
+
 ### Enabling CORS Pre-Flight
 
 Certain CORS requests are considered 'complex' and require an initial


### PR DESCRIPTION
A lot of times when using the code snippet for dynamic origins, developers miss out on cases where origin is not present. For example, while using a Rest tool like Postman or making requests from a server.