### PR TITLE
docs: fix typo in history

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,7 +23,7 @@ This release only changed documentation.
 2.8.0 / 2016-08-23
 ==================
 
-  * Add `optionsSucccessCode` option
+  * Add `optionsSuccessStatus` option
 
 2.7.2 / 2016-08-23
 ==================


### PR DESCRIPTION
`optionsSuccessStatus` not `optionsSucccessCode`