### PR TITLE
Fixed support for maxAge=0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix setting `maxAge` option to `0`
+
 2.8.4 / 2017-07-12
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@
   }
 
   function configureMaxAge(options) {
-    var maxAge = options.maxAge && options.maxAge.toString();
+    var maxAge = (typeof options.maxAge === 'number' || options.maxAge) && options.maxAge.toString()
     if (maxAge && maxAge.length) {
       return {
         key: 'Access-Control-Max-Age',

--- a/test/test.js
+++ b/test/test.js
@@ -672,6 +672,24 @@
         cors(options)(req, res, null);
       });
 
+      it('includes maxAge when specified and equals to zero', function (done) {
+        // arrange
+        var req, res, options
+        options = {
+          maxAge: 0
+        }
+        req = fakeRequest('OPTIONS')
+        res = fakeResponse()
+        res.end = function () {
+          // assert
+          assert.equal(res.getHeader('Access-Control-Max-Age'), '0')
+          done()
+        }
+
+        // act
+        cors(options)(req, res, null)
+      });
+
       it('does not includes maxAge unless specified', function (done) {
         // arrange
         var req, res, next;


### PR DESCRIPTION
Hey,
According to [this spec](https://www.w3.org/TR/cors/#access-control-max-age-response-header) when `Access-Control-Max-Age` is not set, it is up to the user agent to decide the value.
The check `options.maxAge` is faulty when `maxAge` equals to zero, causing it to return `null`, not 0 and different behaviors on different browsers.

Thanks!
Tom