### PR TITLE
CORS  -  IF ELSE CONDITION CHANGED

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,13 +24,15 @@
         }
       }
       return false;
-    } else if (isString(allowedOrigin)) {
-      return origin === allowedOrigin;
-    } else if (allowedOrigin instanceof RegExp) {
-      return allowedOrigin.test(origin);
-    } else {
-      return !!allowedOrigin;
     }
+    if (isString(allowedOrigin)) {
+      return origin === allowedOrigin;
+    }
+    if (allowedOrigin instanceof RegExp) {
+      return allowedOrigin.test(origin);
+    }  
+    return !!allowedOrigin;
+    
   }
 
   function configureOrigin(options, req) {


### PR DESCRIPTION
This **PR** consist the **IF_ELSE** Condition check

_Example_

> while a condition returns a value from current block, It wont go for next block.


Like

`if(age<18){return "No Vote"} else if(age>18){return "Vote"}
`
Instead of this 

we can make like this

`if(age<18){return "No Vote"} if(age>18){return "Vote"}
`

`why because making like this,anyhow once a statement return value from one condition next block wont go so there is no sense to make else if`
