### PR TITLE
feat(origin): pass req in to cors logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,12 +219,12 @@ For details on the effect of each CORS header, read [this](http://www.html5rocks
 
 ## Demo
 
-A demo that illustrates CORS working (and not working) using jQuery is available here: [http://node-cors-client.herokuapp.com/](http://node-cors-client.herokuapp.com/)
+A demo that illustrates CORS working (and not working) using React is available here: [https://node-cors-client.netlify.com](https://node-cors-client.netlify.com)
 
 Code for that demo can be found here:
 
-* Client: [https://github.com/TroyGoode/node-cors-client](https://github.com/TroyGoode/node-cors-client)
-* Server: [https://github.com/TroyGoode/node-cors-server](https://github.com/TroyGoode/node-cors-server)
+* Client: [https://github.com/troygoode/node-cors-client](https://github.com/troygoode/node-cors-client)
+* Server: [https://github.com/troygoode/node-cors-server](https://github.com/troygoode/node-cors-server)
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@
         value: 'Origin'
       }]);
     } else {
-      isAllowed = isOriginAllowed(requestOrigin, options.origin);
+      isAllowed = isOriginAllowed(requestOrigin, options.origin, req);
       // reflect origin
       headers.push([{
         key: 'Access-Control-Allow-Origin',


### PR DESCRIPTION
Allows for an escape-hatch to do unusual CORS checks, whether using the user-agent header or w/e.
This is helpful when using an XHR API from outside the browser (app sandbox, wherever) and trying to pass CORS.