### PR TITLE
Update README to provoide better details about pre-flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ You can also enable pre-flight across-the-board like so:
 app.options('*', cors()) // include before other routes
 ```
 
+NOTE: When using this middleware as an application level middleware (for
+example, `app.use(cors())`), pre-flight requests are already handled for all
+routes.
+
 ### Configuring CORS Asynchronously
 
 ```javascript


### PR DESCRIPTION
As mentioned in issue #195 pre-flight is handled for all the routes by the middleware when used at Application Level. This commit updates the README to provide this missing information.