### PR TITLE
Changed the term whitelist to allowlist in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ var corsOptions = {
 }
 
 app.get('/products/:id', cors(corsOptions), function (req, res, next) {
-  res.json({msg: 'This is CORS-enabled for a whitelisted domain.'})
+  res.json({msg: 'This is CORS-enabled for an allowed domain.'})
 })
 
 app.listen(80, function () {
@@ -169,10 +169,10 @@ var express = require('express')
 var cors = require('cors')
 var app = express()
 
-var whitelist = ['http://example1.com', 'http://example2.com']
+var allowlist = ['http://example1.com', 'http://example2.com']
 var corsOptionsDelegate = function (req, callback) {
   var corsOptions;
-  if (whitelist.indexOf(req.header('Origin')) !== -1) {
+  if (allowlist.indexOf(req.header('Origin')) !== -1) {
     corsOptions = { origin: true } // reflect (enable) the requested origin in the CORS response
   } else {
     corsOptions = { origin: false } // disable CORS for this request
@@ -181,7 +181,7 @@ var corsOptionsDelegate = function (req, callback) {
 }
 
 app.get('/products/:id', cors(corsOptionsDelegate), function (req, res, next) {
-  res.json({msg: 'This is CORS-enabled for a whitelisted domain.'})
+  res.json({msg: 'This is CORS-enabled for an allowed domain.'})
 })
 
 app.listen(80, function () {


### PR DESCRIPTION
Most of the organization such as Microsoft (GitHub) and UK NCSC suggest avoiding terms like "Blacklist" and "Whitelist" due to racial stereotyping. It suggests the use of "blocklist" and "allowlist" instead.

I suggest the community as an extremely popular express middle-ware we can support and involve this "Black Lives Matter" movement too.

https://www.bbc.com/news/technology-53050955
zdnet.com/article/uk-ncsc-to-stop-using-whitelist-and-blacklist-due-to-racial-stereotyping/