### PR TITLE
Allow * in array of origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@
       }
       return false;
     } else if (isString(allowedOrigin)) {
-      return origin === allowedOrigin;
+      return allowedOrigin === '*' || origin === allowedOrigin;
     } else if (allowedOrigin instanceof RegExp) {
       return allowedOrigin.test(origin);
     } else {

--- a/test/test.js
+++ b/test/test.js
@@ -630,6 +630,21 @@ var util = require('util')
         // act
         cors()(req, res, next);
       });
+
+      it('should allow origin if array include *', function (done) {
+        var options = {
+          origin: ['*']
+        };
+        var req = fakeRequest('GET');
+        var res = fakeResponse();
+        var next = function () {
+          // assert
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com')
+          done();
+        };
+
+        cors(options)(req, res, next);
+      });
     });
 
     describe('passing a function to build options', function () {


### PR DESCRIPTION
I added origin via env variable like so:
```javascript
app.enableCors({
    origin: configService.get<string>('CORS_ORIGIN')!.split(','),
});
```
This allowed you to specify multiple domains separated by commas
But I didn’t understand why it didn’t work if I wrote `CORS_ORIGIN: *`

After looking at the source code i saw that there is no check for * in the array of origins

So I think that no matter if I write like this `*` or so `[*]` the result should be the same