### PR TITLE
fix: Respond to preflight request properly when origin evaluated as invalid by custom function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .nyc_output/
 coverage/
 node_modules/

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+Future
+==================
+
+* Respond to preflight request properly when origin evaluated as invalid by custom function
+
 2.8.5 / 2018-11-04
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -221,11 +221,13 @@
 
           if (originCallback) {
             originCallback(req.headers.origin, function (err2, origin) {
-              if (err2 || !origin) {
+              if (err2) {
+                next(err2);
+              } else if (!origin) {
                 if (req.method === 'OPTIONS' && !options.preflightContinue) {
                   respondToPreflight(corsOptions, res);
                 } else {
-                  next(err2);
+                  next();
                 }
               } else {
                 corsOptions.origin = origin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,6 +156,14 @@
     }
   }
 
+  function respondToPreflight(options, res) {
+    // Safari (and potentially other browsers) need content-length 0,
+    // for 204 or they just hang waiting for a body
+    res.statusCode = options.optionsSuccessStatus;
+    res.setHeader('Content-Length', '0');
+    res.end();
+  }
+
   function cors(options, req, res, next) {
     var headers = [],
       method = req.method && req.method.toUpperCase && req.method.toUpperCase();
@@ -173,11 +181,7 @@
       if (options.preflightContinue) {
         next();
       } else {
-        // Safari (and potentially other browsers) need content-length 0,
-        //   for 204 or they just hang waiting for a body
-        res.statusCode = options.optionsSuccessStatus;
-        res.setHeader('Content-Length', '0');
-        res.end();
+        respondToPreflight(options, res);
       }
     } else {
       // actual response
@@ -218,7 +222,11 @@
           if (originCallback) {
             originCallback(req.headers.origin, function (err2, origin) {
               if (err2 || !origin) {
-                next(err2);
+                if (req.method === 'OPTIONS' && !options.preflightContinue) {
+                  respondToPreflight(corsOptions, res);
+                } else {
+                  next(err2);
+                }
               } else {
                 corsOptions.origin = origin;
                 cors(corsOptions, req, res, next);

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@
       headers = [],
       isAllowed;
 
-    if (!options.origin || options.origin === '*') {
+    if (options.origin === '*') {
       // allow any origin
       headers.push([{
         key: 'Access-Control-Allow-Origin',
@@ -223,12 +223,6 @@
             originCallback(req.headers.origin, function (err2, origin) {
               if (err2) {
                 next(err2);
-              } else if (!origin) {
-                if (req.method === 'OPTIONS' && !options.preflightContinue) {
-                  respondToPreflight(corsOptions, res);
-                } else {
-                  next();
-                }
               } else {
                 corsOptions.origin = origin;
                 cors(corsOptions, req, res, next);

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,14 +156,6 @@
     }
   }
 
-  function respondToPreflight(options, res) {
-    // Safari (and potentially other browsers) need content-length 0,
-    // for 204 or they just hang waiting for a body
-    res.statusCode = options.optionsSuccessStatus;
-    res.setHeader('Content-Length', '0');
-    res.end();
-  }
-
   function cors(options, req, res, next) {
     var headers = [],
       method = req.method && req.method.toUpperCase && req.method.toUpperCase();
@@ -181,7 +173,11 @@
       if (options.preflightContinue) {
         next();
       } else {
-        respondToPreflight(options, res);
+        // Safari (and potentially other browsers) need content-length 0,
+        // for 204 or they just hang waiting for a body
+        res.statusCode = options.optionsSuccessStatus;
+        res.setHeader('Content-Length', '0');
+        res.end();
       }
     } else {
       // actual response

--- a/test/test.js
+++ b/test/test.js
@@ -369,6 +369,8 @@ var util = require('util')
       it('should not allow origin when callback returns false for preflight', function (done) {
         var cb = after(1, done);
         var options = {
+          allowedHeaders: ['TestHeader'],
+          methods: ['POST'],
           origin: function (origin, cb) {
             cb(null, false);
           }
@@ -379,8 +381,8 @@ var util = require('util')
         res.on('finish', function () {
           assert.equal(res.statusCode, 204);
           assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined);
-          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined);
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), 'POST');
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'TestHeader');
           assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
           assert.equal(res.getHeader('Access-Control-Max-Age'), undefined);
           cb();

--- a/test/test.js
+++ b/test/test.js
@@ -391,6 +391,23 @@ var util = require('util')
         });
       });
 
+      it('should pass error to the next middleware when returned by callback', function (done) {
+        var e = new Error('Test');
+        var options = {
+          origin: function (origin, cb) {
+            cb(e, false);
+          }
+        };
+        var req = fakeRequest('GET');
+        var res = fakeResponse();
+        var next = function (err) {
+          assert.equal(err, e);
+          done();
+        };
+
+        cors(options)(req, res, next);
+      });
+
       it('should not override options.origin callback', function (done) {
         var req, res, next, options;
         options = {

--- a/test/test.js
+++ b/test/test.js
@@ -366,6 +366,31 @@ var util = require('util')
         cors(options)(req, res, next);
       });
 
+      it('should not allow origin when callback returns false for preflight', function (done) {
+        var cb = after(1, done);
+        var options = {
+          origin: function (origin, cb) {
+            cb(null, false);
+          }
+        };
+        var req = fakeRequest('OPTIONS');
+        var res = fakeResponse();
+
+        res.on('finish', function () {
+          assert.equal(res.statusCode, 204);
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
+          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined);
+          cb();
+        });
+
+        cors(options)(req, res, function (err) {
+          cb(err || new Error('should not be called'));
+        });
+      });
+
       it('should not override options.origin callback', function (done) {
         var req, res, next, options;
         options = {


### PR DESCRIPTION

 - if custom function for origin validation return `err` or `false` for preflight request control is passed to the next middleware
 - that's not the case if origin is defined statically
 - mentioned in and fixes #241