### PR TITLE
Fix functions call with extra parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,11 +163,11 @@
     if (method === 'OPTIONS') {
       // preflight
       headers.push(configureOrigin(options, req));
-      headers.push(configureCredentials(options, req));
-      headers.push(configureMethods(options, req));
+      headers.push(configureCredentials(options))
+      headers.push(configureMethods(options))
       headers.push(configureAllowedHeaders(options, req));
-      headers.push(configureMaxAge(options, req));
-      headers.push(configureExposedHeaders(options, req));
+      headers.push(configureMaxAge(options))
+      headers.push(configureExposedHeaders(options))
       applyHeaders(headers, res);
 
       if (options.preflightContinue) {
@@ -182,8 +182,8 @@
     } else {
       // actual response
       headers.push(configureOrigin(options, req));
-      headers.push(configureCredentials(options, req));
-      headers.push(configureExposedHeaders(options, req));
+      headers.push(configureCredentials(options))
+      headers.push(configureExposedHeaders(options))
       applyHeaders(headers, res);
       next();
     }


### PR DESCRIPTION
Some functions are being called with "req" as second parameter, but it's not required nor is useful in any way, this does not affect the functionality but this should not be done, javascript allows it but it is a little confusing when reading it.

example:

headers.push(configureCredentials(options, **req**)); ---> headers.push(configureCredentials(options));

the function is declared this way:
`function configureCredentials(options) {...`