### PR TITLE
Return current path in callback origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@
   }
 
   function configureOrigin(options, req) {
-    var requestOrigin = req.headers.origin,
+    var requestOrigin = req.headers.origin || '*',
       headers = [],
       isAllowed;
 
@@ -216,7 +216,7 @@
           }
 
           if (originCallback) {
-            originCallback(req.headers.origin, function (err2, origin) {
+            originCallback(req.path, req.headers.origin, function (err2, origin) {
               if (err2 || !origin) {
                 next(err2);
               } else {


### PR DESCRIPTION
The change was added because some endpoints are called without origin, but we must allow them, so a wishList was added so that they can respond without a cors error.

```
const wishList = [ '/path' ]
router.use(cors({
    ...
    ...
    origin        : (path, origin, callback) => {
      if(/domain/i.test(origin) || wishList.includes(path)) return callback(null, true)

      return callback(
        new Error(
          'The CORS policy for this site does not allow access from the specified Origin.'
        ),
        false
      )
    }
  }))