### PR TITLE
feat: handle private network requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ app.listen(80, function () {
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range') or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.
 * `credentials`: Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
 * `maxAge`: Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
+* `allowPrivateNetworkAccess`: Configures the **Access-Control-Allow-Private-Network**. Set to `false` to disable Private Network Requests, otherwise it is allowed.
 * `preflightContinue`: Pass the CORS preflight response to the next handler.
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ app.listen(80, function () {
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range') or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.
 * `credentials`: Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
 * `maxAge`: Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
-* `allowPrivateNetworkAccess`: Configures the **Access-Control-Allow-Private-Network**. Set to `false` to disable Private Network Requests, otherwise it is allowed.
+* `allowPrivateNetwork`: Configures the **Access-Control-Allow-Private-Network**. Set to `false` to disable Private Network Requests, otherwise it is allowed.
 * `preflightContinue`: Pass the CORS preflight response to the next handler.
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@
     origin: '*',
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
-    optionsSuccessStatus: 204
+    optionsSuccessStatus: 204,
+    allowPrivateNetwork: true,
   };
 
   function isString(s) {
@@ -142,11 +143,6 @@
   }
 
   function configurePrivateNetworkAccess(options, req) {
-    if (!options.hasOwnProperty('allowPrivateNetwork')) {
-      // Allow Private Network Requests by default.
-      options.allowPrivateNetwork = true;
-    }
-
     if (req.headers['access-control-request-private-network'] === 'true' && options.allowPrivateNetwork) {
       return {
         key: 'Access-Control-Allow-Private-Network',

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
     optionsSuccessStatus: 204,
-    allowPrivateNetwork: true,
+    allowPrivateNetwork: false,
   };
 
   function isString(s) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,6 +141,21 @@
     return null;
   }
 
+  function configurePrivateNetworkAccess(options, req) {
+    if (!options.hasOwnProperty('allowPrivateNetworkAccess')) {
+      // Allow Private Network Requests by default.
+      options.allowPrivateNetworkAccess = true;
+    }
+
+    if (req.headers['access-control-request-private-network'] === 'true' && options.allowPrivateNetworkAccess) {
+      return {
+        key: 'Access-Control-Allow-Private-Network',
+        value: 'true'
+      };
+    }
+    return null;
+  }
+
   function applyHeaders(headers, res) {
     for (var i = 0, n = headers.length; i < n; i++) {
       var header = headers[i];
@@ -168,6 +183,7 @@
       headers.push(configureAllowedHeaders(options, req));
       headers.push(configureMaxAge(options))
       headers.push(configureExposedHeaders(options))
+      headers.push(configurePrivateNetworkAccess(options, req))
       applyHeaders(headers, res);
 
       if (options.preflightContinue) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,12 +142,12 @@
   }
 
   function configurePrivateNetworkAccess(options, req) {
-    if (!options.hasOwnProperty('allowPrivateNetworkAccess')) {
+    if (!options.hasOwnProperty('allowPrivateNetwork')) {
       // Allow Private Network Requests by default.
-      options.allowPrivateNetworkAccess = true;
+      options.allowPrivateNetwork = true;
     }
 
-    if (req.headers['access-control-request-private-network'] === 'true' && options.allowPrivateNetworkAccess) {
+    if (req.headers['access-control-request-private-network'] === 'true' && options.allowPrivateNetwork) {
       return {
         key: 'Access-Control-Allow-Private-Network',
         value: 'true'

--- a/test/test.js
+++ b/test/test.js
@@ -673,7 +673,7 @@ var util = require('util')
         });
       });
 
-      it('allows private network requests when no options are set', function (done) {
+      it('denies private network requests when no options are set', function (done) {
         // arrange
         var req, res, options, cb;
         options = {};
@@ -682,7 +682,7 @@ var util = require('util')
         cb = after(1, done)
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), 'true')
+          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), undefined)
           cb()
         })
 

--- a/test/test.js
+++ b/test/test.js
@@ -631,11 +631,11 @@ var util = require('util')
         cors()(req, res, next);
       });
 
-      it('allows private network requests when allowPrivateNetworkAccess is true', function (done) {
+      it('allows private network requests when allowPrivateNetwork is true', function (done) {
         // arrange
         var req, res, options, cb;
         options = {
-          allowPrivateNetworkAccess: true,
+          allowPrivateNetwork: true,
         };
         req = fakeRequest('OPTIONS', {'access-control-request-private-network': 'true'});
         res = fakeResponse();
@@ -652,11 +652,11 @@ var util = require('util')
         });
       });
 
-      it('denies private network requests when allowPrivateNetworkAccess is false', function (done) {
+      it('denies private network requests when allowPrivateNetwork is false', function (done) {
         // arrange
         var req, res, options, cb;
         options = {
-          allowPrivateNetworkAccess: false,
+          allowPrivateNetwork: false,
         };
         req = fakeRequest('OPTIONS', {'access-control-request-private-network': 'true'});
         res = fakeResponse();

--- a/test/test.js
+++ b/test/test.js
@@ -630,6 +630,67 @@ var util = require('util')
         // act
         cors()(req, res, next);
       });
+
+      it('allows private network requests when allowPrivateNetworkAccess is true', function (done) {
+        // arrange
+        var req, res, options, cb;
+        options = {
+          allowPrivateNetworkAccess: true,
+        };
+        req = fakeRequest('OPTIONS', {'access-control-request-private-network': 'true'});
+        res = fakeResponse();
+        cb = after(1, done)
+
+        res.on('finish', function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), 'true')
+          cb()
+        })
+
+        // act
+        cors(options)(req, res, function (err) {
+          cb(err || new Error('should not be called'))
+        });
+      });
+
+      it('denies private network requests when allowPrivateNetworkAccess is false', function (done) {
+        // arrange
+        var req, res, options, cb;
+        options = {
+          allowPrivateNetworkAccess: false,
+        };
+        req = fakeRequest('OPTIONS', {'access-control-request-private-network': 'true'});
+        res = fakeResponse();
+        cb = after(1, done)
+
+        res.on('finish', function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), undefined)
+          cb()
+        })
+
+        // act
+        cors(options)(req, res, function (err) {
+          cb(err || new Error('should not be called'))
+        });
+      });
+
+      it('allows private network requests when no options are set', function (done) {
+        // arrange
+        var req, res, options, cb;
+        options = {};
+        req = fakeRequest('OPTIONS', {'access-control-request-private-network': 'true'});
+        res = fakeResponse();
+        cb = after(1, done)
+
+        res.on('finish', function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), 'true')
+          cb()
+        })
+
+        // act
+        cors(options)(req, res, function (err) {
+          cb(err || new Error('should not be called'))
+        });
+      });
     });
 
     describe('passing a function to build options', function () {


### PR DESCRIPTION
This PR adds support for Private Network Requests via CORS, as described in issue #236.

By default this library is allowing all origins, thus in this PR Private Network Requests are allowed by default as well.

(Closes #236)