### PR TITLE
isRegExp: instanceof + check for properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,14 @@
     return typeof s === 'string' || s instanceof String;
   }
 
+  function isRegExp(input) {
+    if (input instanceof RegExp) return true;
+    return typeof input.flags === 'string'
+        && typeof input.ignoreCase === 'boolean'
+        && typeof input.multiline === 'boolean'
+        && typeof input.global === 'boolean';
+  }
+
   function isOriginAllowed(origin, allowedOrigin) {
     if (Array.isArray(allowedOrigin)) {
       for (var i = 0; i < allowedOrigin.length; ++i) {
@@ -26,7 +34,7 @@
       return false;
     } else if (isString(allowedOrigin)) {
       return origin === allowedOrigin;
-    } else if (allowedOrigin instanceof RegExp) {
+    } else if (isRegExp(allowedOrigin)) {
       return allowedOrigin.test(origin);
     } else {
       return !!allowedOrigin;


### PR DESCRIPTION
In a project I am involved in, an Express application is under quite high load. What we discovered, is the app sporadically does not return CORS headers.

If it was misconfigured, I guess, that misbehaviour would be ever present. We use list of RegExps for allowed origins. The only suspicious thing I can potentially blame is `instanceof RegExp` check. This PR changes it to a slightly more complicated property-based check.

Background for why `instanceof RegExp` could be flaky:
- https://github.com/micromatch/anymatch/issues/48
- https://github.com/jonschlinkert/kind-of/blob/master/index.js#L88