### PR TITLE
undefined origin should be treated as not allowed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@
       headers = [],
       isAllowed;
 
-    if (!options.origin || options.origin === '*') {
+    if (options.origin === '*') {
       // allow any origin
       headers.push([{
         key: 'Access-Control-Allow-Origin',


### PR DESCRIPTION
It doesn't make sense to allow a request to process when the origin is not provided. The security is turned upside down. It's easier to intercept a request and get rid of the origin instead of guessing which is the correct one.