### PR TITLE
:bug: Fix readme status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Code for that demo can be found here:
 [coveralls-url]: https://coveralls.io/r/expressjs/cors?branch=master
 [downloads-image]: https://img.shields.io/npm/dm/cors.svg
 [downloads-url]: https://npmjs.org/package/cors
-[github-actions-ci-image]: https://img.shields.io/github/workflow/status/expressjs/cors/ci/master?label=ci
+[github-actions-ci-image]: https://img.shields.io/github/actions/workflow/status/expressjs/cors/ci.yml?branch=master&label=ci
 [github-actions-ci-url]: https://github.com/expressjs/cors?query=workflow%3Aci
 [npm-image]: https://img.shields.io/npm/v/cors.svg
 [npm-url]: https://npmjs.org/package/cors


### PR DESCRIPTION
Before:
![image](https://github.com/expressjs/cors/assets/16977446/ec4d4dfb-7402-4eee-ba63-2d833bda8d21)

After:
![image](https://github.com/expressjs/cors/assets/16977446/7db62066-1197-4569-8508-c2918844f9e5)
