### PR TITLE
feat: handle Chrome CORS preflight private network header

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ app.listen(80, function () {
 * `maxAge`: Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
 * `preflightContinue`: Pass the CORS preflight response to the next handler.
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
+* `allowPrivateNetwork`: Provides **Access-Control-Allow-Private-Network: true** if **Access-Control-Request-Private-Network: true** is presented.
 
 The default configuration is the equivalent of:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,6 +156,19 @@
     }
   }
 
+  function configureAllowPrivateNetwork(options, req) {
+    if (
+      options.allowPrivateNetwork &&
+      req.headers['access-control-request-private-network'] === 'true'
+    ) {
+      return {
+        key: 'Access-Control-Allow-Private-Network',
+        value: 'true',
+      };
+    }
+    return null;
+  }
+
   function cors(options, req, res, next) {
     var headers = [],
       method = req.method && req.method.toUpperCase && req.method.toUpperCase();
@@ -168,6 +181,7 @@
       headers.push(configureAllowedHeaders(options, req));
       headers.push(configureMaxAge(options))
       headers.push(configureExposedHeaders(options))
+      headers.push(configureAllowPrivateNetwork(options, req));
       applyHeaders(headers, res);
 
       if (options.preflightContinue) {

--- a/test/test.js
+++ b/test/test.js
@@ -571,6 +571,39 @@ var util = require('util')
         })
       });
 
+      it('allows private network if explicitly enabled', function (done) {
+        var cb = after(1, done)
+        var req = new FakeRequest('OPTIONS', {
+          'access-control-request-private-network': 'true'
+        })
+        var res = new FakeResponse()
+
+        res.on('finish', function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), 'true')
+          cb()
+        })
+
+        cors({ allowPrivateNetwork: true })(req, res, function (err) {
+          cb(err || new Error('should not be called'))
+        })
+      });
+
+
+      it('not allows private network if explicitly enabled but access-control-request-private-network is missing', function (done) {
+        var cb = after(1, done)
+        var req = new FakeRequest('OPTIONS')
+        var res = new FakeResponse()
+
+        res.on('finish', function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Private-Network'), undefined)
+          cb()
+        })
+
+        cors({ allowPrivateNetwork: true })(req, res, function (err) {
+          cb(err || new Error('should not be called'))
+        })
+      });
+
       it('does not includes credentials unless explicitly enabled', function (done) {
         // arrange
         var req, res, next;


### PR DESCRIPTION
Based on https://developer.chrome.com/blog/private-network-access-preflight/

> Chrome will start sending a CORS preflight request ahead of any [private network request](https://developer.chrome.com/blog/private-network-access-preflight/#what-is-private-network-access-pna) for a subresource, which asks for explicit permission from the target server. This preflight request will carry a new header, Access-Control-Request-Private-Network: true, and the response to it must carry a corresponding header, Access-Control-Allow-Private-Network: true.

This fixes #290 and #236 