### PR TITLE
test: improved test robustness

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -441,7 +441,7 @@ var util = require('util')
         var res = new FakeResponse()
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2')
+          assert.strictEqual(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2')
           assert.equal(res.getHeader('Vary'), undefined)
           cb()
         })


### PR DESCRIPTION
This Pull Request addresses an issue regarding the testing of the handling and generation of `Access-Control-Allow-Headers` header. Through the application of mutation testing, I have identified a potential mutation in the configuration logic that was not covered by the existing tests (issue fully explain in this [threat](https://github.com/expressjs/cors/issues/319)).

**Proposed Change**

To mitigate this, I suggest changing the assertion method from `assert.equal` to `assert.strictEqual` in the `test/test.js` file, specifically at line 444. This alteration would ensure that the tests verify not only the value but also the exact type of the header content, thereby preventing potential type coercion issues.

**Additional Information**

This Pull Request has been created following the directions of @UlisesGascon.

Looking forward to your feedback and approval.

Thank you for considering this enhancement.

Best regards.

---
_Edited by @UlisesGascon_ 

closes https://github.com/expressjs/cors/issues/319