### PR TITLE
feat!: upgrade code to es6 and migrated test to express v5

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,7 @@
 root: true
 env:
   node: true
+  es6: true
 rules:
   indent: ["error", 2, { "SwitchCase": 1 }]
   quotes: ["error", "single"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 0.10
-        - Node.js 4.x
         - Node.js 6.x
         - Node.js 8.x
         - Node.js 10.x
@@ -26,14 +24,6 @@ jobs:
         - Node.js 22.x
 
         include:
-        - name: Node.js 0.10
-          node-version: "0.10"
-          npm-i: mocha@3.5.3 nyc@10.3.2 supertest@2.0.0
-
-        - name: Node.js 4.x
-          node-version: "4.9"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
         - name: Node.js 6.x
           node-version: "6.17"
           npm-i: mocha@6.2.2 nyc@14.1.1
@@ -72,6 +62,9 @@ jobs:
 
         - name: Node.js 22.x
           node-version: "22.0"
+
+        - name: Node.js 23.x
+          node-version: "23.0"
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -9,18 +9,19 @@ CORS is a node.js package for providing a [Connect](http://www.senchalabs.org/co
 
 **[Follow me (@troygoode) on Twitter!](https://twitter.com/intent/user?screen_name=troygoode)**
 
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Simple Usage](#simple-usage-enable-all-cors-requests)
-  * [Enable CORS for a Single Route](#enable-cors-for-a-single-route)
-  * [Configuring CORS](#configuring-cors)
-  * [Configuring CORS w/ Dynamic Origin](#configuring-cors-w-dynamic-origin)
-  * [Enabling CORS Pre-Flight](#enabling-cors-pre-flight)
-  * [Configuring CORS Asynchronously](#configuring-cors-asynchronously)
-* [Configuration Options](#configuration-options)
-* [Demo](#demo)
-* [License](#license)
-* [Author](#author)
+- [cors](#cors)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Simple Usage (Enable *All* CORS Requests)](#simple-usage-enable-all-cors-requests)
+    - [Enable CORS for a Single Route](#enable-cors-for-a-single-route)
+    - [Configuring CORS](#configuring-cors)
+    - [Configuring CORS w/ Dynamic Origin](#configuring-cors-w-dynamic-origin)
+    - [Enabling CORS Pre-Flight](#enabling-cors-pre-flight)
+    - [Configuring CORS Asynchronously](#configuring-cors-asynchronously)
+  - [Configuration Options](#configuration-options)
+  - [Demo](#demo)
+  - [License](#license)
+  - [Author](#author)
 
 ## Installation
 
@@ -37,9 +38,9 @@ $ npm install cors
 ### Simple Usage (Enable *All* CORS Requests)
 
 ```javascript
-var express = require('express')
-var cors = require('cors')
-var app = express()
+const express = require('express')
+const cors = require('cors')
+const app = express()
 
 app.use(cors())
 
@@ -55,9 +56,9 @@ app.listen(80, function () {
 ### Enable CORS for a Single Route
 
 ```javascript
-var express = require('express')
-var cors = require('cors')
-var app = express()
+const express = require('express')
+const cors = require('cors')
+const app = express()
 
 app.get('/products/:id', cors(), function (req, res, next) {
   res.json({msg: 'This is CORS-enabled for a Single Route'})
@@ -71,11 +72,11 @@ app.listen(80, function () {
 ### Configuring CORS
 
 ```javascript
-var express = require('express')
-var cors = require('cors')
-var app = express()
+const express = require('express')
+const cors = require('cors')
+const app = express()
 
-var corsOptions = {
+const corsOptions = {
   origin: 'http://example.com',
   optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
 }
@@ -105,11 +106,11 @@ This function is designed to allow the dynamic loading of allowed origin(s) from
 a backing datasource, like a database.
 
 ```javascript
-var express = require('express')
-var cors = require('cors')
-var app = express()
+const express = require('express')
+const cors = require('cors')
+const app = express()
 
-var corsOptions = {
+const corsOptions = {
   origin: function (origin, callback) {
     // db.loadOrigins is an example call to load
     // a list of origins from a backing database
@@ -138,9 +139,9 @@ pre-flighting, you must add a new OPTIONS handler for the route you want
 to support:
 
 ```javascript
-var express = require('express')
-var cors = require('cors')
-var app = express()
+const express = require('express')
+const cors = require('cors')
+const app = express()
 
 app.options('/products/:id', cors()) // enable pre-flight request for DELETE request
 app.del('/products/:id', cors(), function (req, res, next) {
@@ -165,12 +166,12 @@ routes.
 ### Configuring CORS Asynchronously
 
 ```javascript
-var express = require('express')
-var cors = require('cors')
-var app = express()
+const express = require('express')
+const cors = require('cors')
+const app = express()
 
-var allowlist = ['http://example1.com', 'http://example2.com']
-var corsOptionsDelegate = function (req, callback) {
+const allowlist = ['http://example1.com', 'http://example2.com']
+const corsOptionsDelegate = function (req, callback) {
   var corsOptions;
   if (allowlist.indexOf(req.header('Origin')) !== -1) {
     corsOptions = { origin: true } // reflect (enable) the requested origin in the CORS response

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,10 @@
 
   'use strict';
 
-  var assign = require('object-assign');
-  var vary = require('vary');
+  const assign = require('object-assign');
+  const vary = require('vary');
 
-  var defaults = {
+  const defaults = {
     origin: '*',
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
@@ -18,7 +18,7 @@
 
   function isOriginAllowed(origin, allowedOrigin) {
     if (Array.isArray(allowedOrigin)) {
-      for (var i = 0; i < allowedOrigin.length; ++i) {
+      for (let i = 0; i < allowedOrigin.length; ++i) {
         if (isOriginAllowed(origin, allowedOrigin[i])) {
           return true;
         }
@@ -34,9 +34,9 @@
   }
 
   function configureOrigin(options, req) {
-    var requestOrigin = req.headers.origin,
-      headers = [],
-      isAllowed;
+    const requestOrigin = req.headers.origin;
+    let headers = [];
+    let isAllowed;
 
     if (!options.origin || options.origin === '*') {
       // allow any origin
@@ -71,7 +71,7 @@
   }
 
   function configureMethods(options) {
-    var methods = options.methods;
+    let methods = options.methods;
     if (methods.join) {
       methods = options.methods.join(','); // .methods is an array, so turn it into a string
     }
@@ -92,8 +92,8 @@
   }
 
   function configureAllowedHeaders(options, req) {
-    var allowedHeaders = options.allowedHeaders || options.headers;
-    var headers = [];
+    let allowedHeaders = options.allowedHeaders || options.headers;
+    let headers = [];
 
     if (!allowedHeaders) {
       allowedHeaders = req.headers['access-control-request-headers']; // .headers wasn't specified, so reflect the request headers
@@ -115,7 +115,7 @@
   }
 
   function configureExposedHeaders(options) {
-    var headers = options.exposedHeaders;
+    let headers = options.exposedHeaders;
     if (!headers) {
       return null;
     } else if (headers.join) {
@@ -131,7 +131,7 @@
   }
 
   function configureMaxAge(options) {
-    var maxAge = (typeof options.maxAge === 'number' || options.maxAge) && options.maxAge.toString()
+    const maxAge = (typeof options.maxAge === 'number' || options.maxAge) && options.maxAge.toString();
     if (maxAge && maxAge.length) {
       return {
         key: 'Access-Control-Max-Age',
@@ -142,8 +142,8 @@
   }
 
   function applyHeaders(headers, res) {
-    for (var i = 0, n = headers.length; i < n; i++) {
-      var header = headers[i];
+    for (let i = 0, n = headers.length; i < n; i++) {
+      const header = headers[i];
       if (header) {
         if (Array.isArray(header)) {
           applyHeaders(header, res);
@@ -157,17 +157,17 @@
   }
 
   function cors(options, req, res, next) {
-    var headers = [],
-      method = req.method && req.method.toUpperCase && req.method.toUpperCase();
+    let headers = [];
+    const method = req.method && req.method.toUpperCase && req.method.toUpperCase();
 
     if (method === 'OPTIONS') {
       // preflight
       headers.push(configureOrigin(options, req));
-      headers.push(configureCredentials(options))
-      headers.push(configureMethods(options))
+      headers.push(configureCredentials(options));
+      headers.push(configureMethods(options));
       headers.push(configureAllowedHeaders(options, req));
-      headers.push(configureMaxAge(options))
-      headers.push(configureExposedHeaders(options))
+      headers.push(configureMaxAge(options));
+      headers.push(configureExposedHeaders(options));
       applyHeaders(headers, res);
 
       if (options.preflightContinue) {
@@ -182,8 +182,8 @@
     } else {
       // actual response
       headers.push(configureOrigin(options, req));
-      headers.push(configureCredentials(options))
-      headers.push(configureExposedHeaders(options))
+      headers.push(configureCredentials(options));
+      headers.push(configureExposedHeaders(options));
       applyHeaders(headers, res);
       next();
     }
@@ -191,7 +191,7 @@
 
   function middlewareWrapper(o) {
     // if options are static (either via defaults or custom options passed in), wrap in a function
-    var optionsCallback = null;
+    let optionsCallback = null;
     if (typeof o === 'function') {
       optionsCallback = o;
     } else {
@@ -205,8 +205,8 @@
         if (err) {
           next(err);
         } else {
-          var corsOptions = assign({}, defaults, options);
-          var originCallback = null;
+          const corsOptions = assign({}, defaults, options);
+          let originCallback = null;
           if (corsOptions.origin && typeof corsOptions.origin === 'function') {
             originCallback = corsOptions.origin;
           } else if (corsOptions.origin) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
   'use strict';
 
-  const assign = require('object-assign');
   const vary = require('vary');
 
   const defaults = {
@@ -205,7 +204,7 @@
         if (err) {
           next(err);
         } else {
-          const corsOptions = assign({}, defaults, options);
+          const corsOptions = Object.assign({}, defaults, options);
           let originCallback = null;
           if (corsOptions.origin && typeof corsOptions.origin === 'function') {
             originCallback = corsOptions.origin;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "after": "0.8.2",
     "eslint": "7.30.0",
-    "express": "4.17.1",
+    "express": "5.0.1",
     "mocha": "9.1.1",
     "nyc": "15.1.0",
     "supertest": "6.1.3"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 6"
   },
   "scripts": {
     "test": "npm run lint && npm run test-ci",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">= 6.4.0"
+    "node": ">= 18"
   },
   "scripts": {
     "test": "npm run lint && npm run test-ci",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "repository": "expressjs/cors",
   "main": "./lib/index.js",
   "dependencies": {
-    "object-assign": "^4",
     "vary": "^1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 6.4.0"
   },
   "scripts": {
     "test": "npm run lint && npm run test-ci",

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,2 +1,3 @@
 env:
   mocha: true
+  es6: true

--- a/test/error-response.js
+++ b/test/error-response.js
@@ -2,11 +2,11 @@
 
   'use strict';
 
-  var express = require('express'),
-    supertest = require('supertest'),
-    cors = require('../lib');
+  const express = require('express');
+  const supertest = require('supertest');
+  const cors = require('../lib');
 
-  var app;
+  let app;
 
   /* -------------------------------------------------------------------------- */
 
@@ -42,7 +42,7 @@
         .expect(500)
         .expect('Access-Control-Allow-Origin', '*')
         .expect(/Error: nope/)
-        .end(done)
+        .end(done);
     });
 
     it('401', function (done) {
@@ -51,7 +51,7 @@
         .expect(401)
         .expect('Access-Control-Allow-Origin', '*')
         .expect('unauthorized')
-        .end(done)
+        .end(done);
     });
 
     it('404', function (done) {
@@ -59,7 +59,7 @@
         .post('/four-oh-four')
         .expect(404)
         .expect('Access-Control-Allow-Origin', '*')
-        .end(done)
+        .end(done);
     });
   });
 

--- a/test/example-app.js
+++ b/test/example-app.js
@@ -2,12 +2,12 @@
 
   'use strict';
 
-  var express = require('express'),
-    supertest = require('supertest'),
-    cors = require('../lib');
+  const express = require('express');
+  const supertest = require('supertest');
+  const cors = require('../lib');
 
-  var simpleApp,
-    complexApp;
+  let simpleApp;
+  let complexApp;
 
   /* -------------------------------------------------------------------------- */
 
@@ -40,14 +40,14 @@
           .expect(200)
           .expect('Access-Control-Allow-Origin', '*')
           .expect('Hello World (Get)')
-          .end(done)
+          .end(done);
       });
       it('HEAD works', function (done) {
         supertest(simpleApp)
           .head('/')
           .expect(204)
           .expect('Access-Control-Allow-Origin', '*')
-          .end(done)
+          .end(done);
       });
       it('POST works', function (done) {
         supertest(simpleApp)
@@ -55,7 +55,7 @@
           .expect(200)
           .expect('Access-Control-Allow-Origin', '*')
           .expect('Hello World (Post)')
-          .end(done)
+          .end(done);
       });
     });
 
@@ -65,7 +65,7 @@
           .options('/')
           .expect(204)
           .expect('Access-Control-Allow-Origin', '*')
-          .end(done)
+          .end(done);
       });
       it('DELETE works', function (done) {
         supertest(complexApp)
@@ -73,7 +73,7 @@
           .expect(200)
           .expect('Access-Control-Allow-Origin', '*')
           .expect('Hello World (Delete)')
-          .end(done)
+          .end(done);
       });
     });
   });

--- a/test/issue-2.js
+++ b/test/issue-2.js
@@ -2,12 +2,12 @@
 
   'use strict';
 
-  var express = require('express'),
-    supertest = require('supertest'),
-    cors = require('../lib');
+  const express = require('express');
+  const supertest = require('supertest');
+  const cors = require('../lib');
 
-  var app,
-    corsOptions;
+  let app;
+  let corsOptions;
 
   /* -------------------------------------------------------------------------- */
 
@@ -25,14 +25,14 @@
 
   /* -------------------------------------------------------------------------- */
 
-  describe('issue  #2', function () {
+  describe('issue #2', function () {
     it('OPTIONS works', function (done) {
       supertest(app)
         .options('/api/login')
         .set('Origin', 'http://example.com')
         .expect(204)
         .expect('Access-Control-Allow-Origin', 'http://example.com')
-        .end(done)
+        .end(done);
     });
     it('POST works', function (done) {
       supertest(app)
@@ -41,7 +41,7 @@
         .expect(200)
         .expect('Access-Control-Allow-Origin', 'http://example.com')
         .expect('LOGIN')
-        .end(done)
+        .end(done);
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,39 +1,38 @@
-'use strict'
+'use strict';
 
-var EventEmitter = require('events').EventEmitter
-var util = require('util')
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
 
-;(function () {
+(function () {
   'use strict';
 
-  var after = require('after')
-  var assert = require('assert')
-  var cors = require('..')
+  const after = require('after');
+  const assert = require('assert');
+  const cors = require('..');
 
-  var fakeRequest = function (method, headers) {
-    return new FakeRequest(method, headers)
-  }
+  const fakeRequest = function (method, headers) {
+    return new FakeRequest(method, headers);
+  };
 
-  var fakeResponse = function () {
-    return new FakeResponse()
-  }
+  const fakeResponse = function () {
+    return new FakeResponse();
+  };
 
   describe('cors', function () {
     it('does not alter `options` configuration object', function () {
-      var options = Object.freeze({
+      const options = Object.freeze({
         origin: 'custom-origin'
       });
       assert.doesNotThrow(function () {
         cors(options);
-      })
+      });
     });
 
     it('passes control to next middleware', function (done) {
       // arrange
-      var req, res, next;
-      req = fakeRequest('GET');
-      res = fakeResponse();
-      next = function () {
+      const req = fakeRequest('GET');
+      const res = fakeResponse();
+      const next = function () {
         done();
       };
 
@@ -42,87 +41,86 @@ var util = require('util')
     });
 
     it('shortcircuits preflight requests', function (done) {
-      var cb = after(1, done)
-      var req = new FakeRequest('OPTIONS')
-      var res = new FakeResponse()
+      const cb = after(1, done);
+      const req = new FakeRequest('OPTIONS');
+      const res = new FakeResponse();
 
       res.on('finish', function () {
-        assert.equal(res.statusCode, 204)
-        cb()
-      })
+        assert.equal(res.statusCode, 204);
+        cb();
+      });
 
       cors()(req, res, function (err) {
-        cb(err || new Error('should not be called'))
-      })
+        cb(err || new Error('should not be called'));
+      });
     });
 
     it('can configure preflight success response status code', function (done) {
-      var cb = after(1, done)
-      var req = new FakeRequest('OPTIONS')
-      var res = new FakeResponse()
+      const cb = after(1, done);
+      const req = new FakeRequest('OPTIONS');
+      const res = new FakeResponse();
 
       res.on('finish', function () {
-        assert.equal(res.statusCode, 200)
-        cb()
-      })
+        assert.equal(res.statusCode, 200);
+        cb();
+      });
 
       // act
       cors({ optionsSuccessStatus: 200 })(req, res, function (err) {
-        cb(err || new Error('should not be called'))
-      })
+        cb(err || new Error('should not be called'));
+      });
     });
 
     it('doesn\'t shortcircuit preflight requests with preflightContinue option', function (done) {
-      var cb = after(1, done)
-      var req = new FakeRequest('OPTIONS')
-      var res = new FakeResponse()
+      const cb = after(1, done);
+      const req = new FakeRequest('OPTIONS');
+      const res = new FakeResponse();
 
       res.on('finish', function () {
-        cb(new Error('should not be called'))
-      })
+        cb(new Error('should not be called'));
+      });
 
       cors({ preflightContinue: true })(req, res, function (err) {
-        if (err) return cb(err)
-        setTimeout(cb, 10)
-      })
+        if (err) return cb(err);
+        setTimeout(cb, 10);
+      });
     });
 
     it('normalizes method names', function (done) {
-      var cb = after(1, done)
-      var req = new FakeRequest('options')
-      var res = new FakeResponse()
+      const cb = after(1, done);
+      const req = new FakeRequest('options');
+      const res = new FakeResponse();
 
       res.on('finish', function () {
-        assert.equal(res.statusCode, 204)
-        cb()
-      })
+        assert.equal(res.statusCode, 204);
+        cb();
+      });
 
       cors()(req, res, function (err) {
-        cb(err || new Error('should not be called'))
-      })
+        cb(err || new Error('should not be called'));
+      });
     });
 
     it('includes Content-Length response header', function (done) {
-      var cb = after(1, done)
-      var req = new FakeRequest('OPTIONS')
-      var res = new FakeResponse()
+      const cb = after(1, done);
+      const req = new FakeRequest('OPTIONS');
+      const res = new FakeResponse();
 
       res.on('finish', function () {
-        assert.equal(res.getHeader('Content-Length'), '0')
-        cb()
-      })
+        assert.equal(res.getHeader('Content-Length'), '0');
+        cb();
+      });
 
       cors()(req, res, function (err) {
-        cb(err || new Error('should not be called'))
-      })
+        cb(err || new Error('should not be called'));
+      });
     });
 
     it('no options enables default CORS to all origins', function (done) {
       // arrange
-      var req, res, next;
-      req = fakeRequest('GET');
-      res = fakeResponse();
-      next = function () {
+      const req = fakeRequest('GET');
+      const res = fakeResponse();
+      const next = function () {
         // assert
         assert.equal(res.getHeader('Access-Control-Allow-Origin'), '*')
         assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined)
@@ -130,13 +128,13 @@ var util = require('util')
       };
 
       // act
-      cors()(req, res, next);
+      cors()(req, res, next)
     });
 
     it('OPTION call with no options enables default CORS to all origins and methods', function (done) {
-      var cb = after(1, done)
-      var req = new FakeRequest('OPTIONS')
-      var res = new FakeResponse()
+      const cb = after(1, done)
+      const req = new FakeRequest('OPTIONS')
+      const res = new FakeResponse()
 
       res.on('finish', function () {
         assert.equal(res.statusCode, 204)
@@ -152,10 +150,10 @@ var util = require('util')
 
     describe('passing static options', function () {
       it('overrides defaults', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
-        var options = {
+        const cb = after(1, done)
+        const req = new FakeRequest('OPTIONS')
+        const res = new FakeResponse()
+        const options = {
           origin: 'http://example.com',
           methods: ['FOO', 'bar'],
           headers: ['FIZZ', 'buzz'],
@@ -168,177 +166,152 @@ var util = require('util')
           assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com')
           assert.equal(res.getHeader('Access-Control-Allow-Methods'), 'FOO,bar')
           assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'FIZZ,buzz')
-          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), 'true')
-          assert.equal(res.getHeader('Access-Control-Max-Age'), '123')
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), 'true');
+          assert.equal(res.getHeader('Access-Control-Max-Age'), '123');
           cb()
         })
 
         cors(options)(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
-      it('matches request origin against regexp', function(done) {
-        var req = fakeRequest('GET');
-        var res = fakeResponse();
-        var options = { origin: /:\/\/(.+\.)?example.com$/ }
-        cors(options)(req, res, function(err) {
-          assert.ifError(err)
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), req.headers.origin)
-          assert.equal(res.getHeader('Vary'), 'Origin')
+      it('matches request origin against regexp', function (done) {
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const options = { origin: /:\/\/(.+\.)?example.com$/ };
+        cors(options)(req, res, function (err) {
+          assert.ifError(err);
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), req.headers.origin);
+          assert.equal(res.getHeader('Vary'), 'Origin');
           return done();
         });
       });
 
-      it('matches request origin against array of origin checks', function(done) {
-        var req = fakeRequest('GET');
-        var res = fakeResponse();
-        var options = { origin: [ /foo\.com$/, 'http://example.com' ] }
-        cors(options)(req, res, function(err) {
-          assert.ifError(err)
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), req.headers.origin)
-          assert.equal(res.getHeader('Vary'), 'Origin')
+      it('matches request origin against array of origin checks', function (done) {
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const options = { origin: [/foo\.com$/, 'http://example.com'] };
+        cors(options)(req, res, function (err) {
+          assert.ifError(err);
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), req.headers.origin);
+          assert.equal(res.getHeader('Vary'), 'Origin');
           return done();
         });
       });
 
-      it('doesn\'t match request origin against array of invalid origin checks', function(done) {
-        var req = fakeRequest('GET');
-        var res = fakeResponse();
-        var options = { origin: [ /foo\.com$/, 'bar.com' ] };
-        cors(options)(req, res, function(err) {
-          assert.ifError(err)
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined)
-          assert.equal(res.getHeader('Vary'), 'Origin')
+      it('doesn\'t match request origin against array of invalid origin checks', function (done) {
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const options = { origin: [/foo\.com$/, 'bar.com'] };
+        cors(options)(req, res, function (err) {
+          assert.ifError(err);
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined);
+          assert.equal(res.getHeader('Vary'), 'Origin');
           return done();
         });
       });
 
       it('origin of false disables cors', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: false,
           methods: ['FOO', 'bar'],
           headers: ['FIZZ', 'buzz'],
           credentials: true,
           maxAge: 123
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined)
-          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined)
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
+          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined);
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('can override origin', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: 'http://example.com'
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com');
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('includes Vary header for specific origins', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: 'http://example.com'
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Vary'), 'Origin')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Vary'), 'Origin');
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('appends to an existing Vary header', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: 'http://example.com'
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
         res.setHeader('Vary', 'Foo');
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Vary'), 'Foo, Origin')
+        const next = function () {
+          assert.equal(res.getHeader('Vary'), 'Foo, Origin');
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('origin defaults to *', function (done) {
-        // arrange
-        var req, res, next;
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), '*')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), '*');
           done();
         };
 
-        // act
         cors()(req, res, next);
       });
 
       it('specifying true for origin reflects requesting origin', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: true
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com');
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('should allow origin when callback returns true', function (done) {
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: function (sentOrigin, cb) {
             cb(null, true);
           }
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com');
           done();
         };
 
@@ -346,20 +319,19 @@ var util = require('util')
       });
 
       it('should not allow origin when callback returns false', function (done) {
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: function (sentOrigin, cb) {
             cb(null, false);
           }
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined)
-          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined)
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
+          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined);
           done();
         };
 
@@ -367,17 +339,16 @@ var util = require('util')
       });
 
       it('should not override options.origin callback', function (done) {
-        var req, res, next, options;
-        options = {
+        const options = {
           origin: function (sentOrigin, cb) {
-            cb(null, sentOrigin === 'http://example.com')
+            cb(null, sentOrigin === 'http://example.com');
           }
         };
 
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com')
+        let req = fakeRequest('GET');
+        let res = fakeResponse();
+        let next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'http://example.com');
         };
 
         cors(options)(req, res, next);
@@ -388,264 +359,272 @@ var util = require('util')
         res = fakeResponse();
 
         next = function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined)
-          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined)
-          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined)
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined);
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
+          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined);
           done();
         };
 
         cors(options)(req, res, next);
       });
 
-
       it('can override methods', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
-        var options = {
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
+        const options = {
           methods: ['method1', 'method2']
         };
 
         res.on('finish', function () {
-          assert.equal(res.statusCode, 204)
-          assert.equal(res.getHeader('Access-Control-Allow-Methods'), 'method1,method2')
-          cb()
-        })
+          assert.equal(res.statusCode, 204);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), 'method1,method2');
+          cb();
+        });
 
         cors(options)(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('methods defaults to GET, HEAD, PUT, PATCH, POST, DELETE', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.equal(res.statusCode, 204)
-          assert.equal(res.getHeader('Access-Control-Allow-Methods'), 'GET,HEAD,PUT,PATCH,POST,DELETE')
-          cb()
-        })
+          assert.equal(res.statusCode, 204);
+          assert.equal(res.getHeader('Access-Control-Allow-Methods'), 'GET,HEAD,PUT,PATCH,POST,DELETE');
+          cb();
+        });
 
         cors()(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('can specify allowed headers as array', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.strictEqual(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2')
-          assert.equal(res.getHeader('Vary'), undefined)
-          cb()
-        })
+          assert.strictEqual(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2');
+          assert.equal(res.getHeader('Vary'), undefined);
+          cb();
+        });
 
         cors({ allowedHeaders: ['header1', 'header2'] })(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('can specify allowed headers as string', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2')
-          assert.equal(res.getHeader('Vary'), undefined)
-          cb()
-        })
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2');
+          assert.equal(res.getHeader('Vary'), undefined);
+          cb();
+        });
 
         cors({ allowedHeaders: 'header1,header2' })(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('specifying an empty list or string of allowed headers will result in no response header for allowed headers', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           allowedHeaders: []
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined)
-          assert.equal(res.getHeader('Vary'), undefined)
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined);
+          assert.equal(res.getHeader('Vary'), undefined);
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('if no allowed headers are specified, defaults to requested allowed headers', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'x-header-1, x-header-2')
-          assert.equal(res.getHeader('Vary'), 'Access-Control-Request-Headers')
-          cb()
-        })
+          assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'x-header-1, x-header-2');
+          assert.equal(res.getHeader('Vary'), 'Access-Control-Request-Headers');
+          cb();
+        });
 
         cors()(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('can specify exposed headers as array', function (done) {
-        // arrange
-        var req, res, options, next;
-        options = {
+        const options = {
           exposedHeaders: ['custom-header1', 'custom-header2']
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Expose-Headers'), 'custom-header1,custom-header2')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Expose-Headers'), 'custom-header1,custom-header2');
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('can specify exposed headers as string', function (done) {
-        // arrange
-        var req, res, options, next;
-        options = {
+        const options = {
           exposedHeaders: 'custom-header1,custom-header2'
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Expose-Headers'), 'custom-header1,custom-header2')
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Expose-Headers'), 'custom-header1,custom-header2');
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('specifying an empty list or string of exposed headers will result in no response header for exposed headers', function (done) {
-        // arrange
-        var req, res, next, options;
-        options = {
+        const options = {
           exposedHeaders: []
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Expose-Headers'), undefined)
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Expose-Headers'), undefined);
           done();
         };
 
-        // act
         cors(options)(req, res, next);
       });
 
       it('includes credentials if explicitly enabled', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), 'true')
-          cb()
-        })
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), 'true');
+          cb();
+        });
 
         cors({ credentials: true })(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
-      it('does not includes credentials unless explicitly enabled', function (done) {
-        // arrange
-        var req, res, next;
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined)
+      it('does not include credentials unless explicitly enabled', function (done) {
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const next = function () {
+          assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
           done();
         };
 
-        // act
         cors()(req, res, next);
       });
 
       it('includes maxAge when specified', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Max-Age'), '456')
-          cb()
-        })
+          assert.equal(res.getHeader('Access-Control-Max-Age'), '456');
+          cb();
+        });
 
         cors({ maxAge: 456 })(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('includes maxAge when specified and equals to zero', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Max-Age'), '0')
-          cb()
-        })
+          assert.equal(res.getHeader('Access-Control-Max-Age'), '0');
+          cb();
+        });
 
         cors({ maxAge: 0 })(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
-      it('does not includes maxAge unless specified', function (done) {
-        // arrange
-        var req, res, next;
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
-          // assert
-          assert.equal(res.getHeader('Access-Control-Max-Age'), undefined)
-          done();
-        };
+    });
 
-        // act
-        cors()(req, res, next);
+    it('includes maxAge when specified', function (done) {
+      const cb = after(1, done);
+      const req = new FakeRequest('OPTIONS');
+      const res = new FakeResponse();
+
+      res.on('finish', function () {
+        assert.equal(res.getHeader('Access-Control-Max-Age'), '456');
+        cb();
       });
+
+      cors({ maxAge: 456 })(req, res, function (err) {
+        cb(err || new Error('should not be called'));
+      });
+    });
+
+    it('includes maxAge when specified and equals to zero', function (done) {
+      const cb = after(1, done);
+      const req = new FakeRequest('OPTIONS');
+      const res = new FakeResponse();
+
+      res.on('finish', function () {
+        assert.equal(res.getHeader('Access-Control-Max-Age'), '0');
+        cb();
+      });
+
+      cors({ maxAge: 0 })(req, res, function (err) {
+        cb(err || new Error('should not be called'));
+      });
+    });
+
+    it('does not include maxAge unless specified', function (done) {
+      // arrange
+      const req = fakeRequest('GET');
+      const res = fakeResponse();
+      const next = function () {
+        // assert
+        assert.equal(res.getHeader('Access-Control-Max-Age'), undefined);
+        done();
+      };
+
+      // act
+      cors()(req, res, next);
     });
 
     describe('passing a function to build options', function () {
       it('handles options specified via callback', function (done) {
         // arrange
-        var req, res, next, delegate;
-        delegate = function (req2, cb) {
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const delegate = function (req2, cb) {
           cb(null, {
             origin: 'delegate.com'
           });
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function () {
+        const next = function () {
           // assert
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'delegate.com')
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'delegate.com');
           done();
         };
 
@@ -654,10 +633,10 @@ var util = require('util')
       });
 
       it('handles options specified via callback for preflight', function (done) {
-        var cb = after(1, done)
-        var req = new FakeRequest('OPTIONS')
-        var res = new FakeResponse()
-        var delegate = function (req2, cb) {
+        const cb = after(1, done);
+        const req = new FakeRequest('OPTIONS');
+        const res = new FakeResponse();
+        const delegate = function (req2, cb) {
           cb(null, {
             origin: 'delegate.com',
             maxAge: 1000
@@ -665,27 +644,26 @@ var util = require('util')
         };
 
         res.on('finish', function () {
-          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'delegate.com')
-          assert.equal(res.getHeader('Access-Control-Max-Age'), '1000')
-          cb()
-        })
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), 'delegate.com');
+          assert.equal(res.getHeader('Access-Control-Max-Age'), '1000');
+          cb();
+        });
 
         cors(delegate)(req, res, function (err) {
-          cb(err || new Error('should not be called'))
-        })
+          cb(err || new Error('should not be called'));
+        });
       });
 
       it('handles error specified via callback', function (done) {
         // arrange
-        var req, res, next, delegate;
-        delegate = function (req2, cb) {
+        const req = fakeRequest('GET');
+        const res = fakeResponse();
+        const delegate = function (req2, cb) {
           cb('some error');
         };
-        req = fakeRequest('GET');
-        res = fakeResponse();
-        next = function (err) {
+        const next = function (err) {
           // assert
-          assert.equal(err, 'some error')
+          assert.equal(err, 'some error');
           done();
         };
 
@@ -695,37 +673,36 @@ var util = require('util')
     });
   });
 
-}());
-
-function FakeRequest (method, headers) {
-  this.headers = headers || {
-    'origin': 'http://example.com',
-    'access-control-request-headers': 'x-header-1, x-header-2'
+  function FakeRequest(method, headers) {
+    this.headers = headers || {
+      'origin': 'http://example.com',
+      'access-control-request-headers': 'x-header-1, x-header-2'
+    };
+    this.method = method || 'GET';
   }
-  this.method = method || 'GET'
-}
 
-function FakeResponse () {
-  this._headers = {}
-  this.statusCode = 200
-}
+  function FakeResponse() {
+    this._headers = {};
+    this.statusCode = 200;
+  }
 
-util.inherits(FakeResponse, EventEmitter)
+  util.inherits(FakeResponse, EventEmitter);
 
-FakeResponse.prototype.end = function end () {
-  var response = this
+  FakeResponse.prototype.end = function end() {
+    const response = this;
 
-  process.nextTick(function () {
-    response.emit('finish')
-  })
-}
+    process.nextTick(function () {
+      response.emit('finish');
+    });
+  };
 
-FakeResponse.prototype.getHeader = function getHeader (name) {
-  var key = name.toLowerCase()
-  return this._headers[key]
-}
+  FakeResponse.prototype.getHeader = function getHeader(name) {
+    const key = name.toLowerCase();
+    return this._headers[key];
+  };
 
-FakeResponse.prototype.setHeader = function setHeader (name, value) {
-  var key = name.toLowerCase()
-  this._headers[key] = value
-}
+  FakeResponse.prototype.setHeader = function setHeader(name, value) {
+    const key = name.toLowerCase();
+    this._headers[key] = value;
+  };
+})();


### PR DESCRIPTION
With the release of Express v5, the minimum supported Node.js version has been updated to v18. In light of this, I noticed [this previous PR](https://github.com/expressjs/cors/pull/281) that attempted to introduce ES6 features such as `let` and `const`. That PR was closed with the understanding that the package would follow the Node.js version support of Express.

Since Express has now bumped its Node.js requirement to v18+, it is an opportune time to update the codebase to replace `var` with `let` and `const`, which are now fully supported by the minimum required Node.js version.

This change aims to modernize the code and take advantage of ES6 features for better readability, performance, and maintainability.

I also refactored the code so  [object-assign](https://www.npmjs.com/package/object-assign) is no longer needed, as we can replace it with `Object.assign` as this was introduced in node v4
