### PR TITLE
docs: remove broken link to demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ CORS is a node.js package for providing a [Connect](http://www.senchalabs.org/co
   * [Enabling CORS Pre-Flight](#enabling-cors-pre-flight)
   * [Configuring CORS Asynchronously](#configuring-cors-asynchronously)
 * [Configuration Options](#configuration-options)
-* [Demo](#demo)
 * [License](#license)
 * [Author](#author)
 
@@ -217,15 +216,6 @@ The default configuration is the equivalent of:
 ```
 
 For details on the effect of each CORS header, read [this](https://web.dev/cross-origin-resource-sharing/) article on web.dev.
-
-## Demo
-
-A demo that illustrates CORS working (and not working) using React is available here: [https://node-cors-client.netlify.com](https://node-cors-client.netlify.com)
-
-Code for that demo can be found here:
-
-* Client: [https://github.com/troygoode/node-cors-client](https://github.com/troygoode/node-cors-client)
-* Server: [https://github.com/troygoode/node-cors-server](https://github.com/troygoode/node-cors-server)
 
 ## License
 


### PR DESCRIPTION
The site is no longer being hosted. Better to not have a broken link in the readme.

Resolves #343 

---
labels: require-triage
---

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->