### PR TITLE
chore: add node v25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         - Node.js 22.x
         - Node.js 23.x
         - Node.js 24.x
+        - Node.js 25.x
 
         include:
         - name: Node.js 0.10
@@ -86,6 +87,9 @@ jobs:
 
         - name: Node.js 24.x
           node-version: "24"
+
+        - name: Node.js 25.x
+          node-version: "25"
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Add Node.js 25 support to CI

This PR adds Node.js 25.x to the CI test matrix to ensure compatibility with the latest Node.js release.

### Changes

- Add Node.js 25.x to the test matrix
- Configure `node-version: "25"` to automatically use the latest v25 minor/patch version

### Node.js 25 Information

Node.js 25 was released on October 15, 2025, and is currently in "Current" status. Testing against this version ensures the package remains compatible with the latest Node.js features and improvements.

### Testing

The CI will now run tests against Node.js 25.x alongside all other supported versions (0.10 - 25.x).