### PR TITLE
fix: do not set Vary: Origin for static string origin option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 (function () {
-
   'use strict';
 
   var assign = require('object-assign');
@@ -45,14 +44,11 @@
         value: '*'
       }]);
     } else if (isString(options.origin)) {
-      // fixed origin
+      // fixed origin: response is always the same regardless of request Origin,
+      // so Vary: Origin must NOT be set (per fetch spec, see issue #332)
       headers.push([{
         key: 'Access-Control-Allow-Origin',
         value: options.origin
-      }]);
-      headers.push([{
-        key: 'Vary',
-        value: 'Origin'
       }]);
     } else {
       isAllowed = isOriginAllowed(requestOrigin, options.origin);
@@ -66,7 +62,6 @@
         value: 'Origin'
       }]);
     }
-
     return headers;
   }
 
@@ -94,7 +89,6 @@
   function configureAllowedHeaders(options, req) {
     var allowedHeaders = options.allowedHeaders || options.headers;
     var headers = [];
-
     if (!allowedHeaders) {
       allowedHeaders = req.headers['access-control-request-headers']; // .headers wasn't specified, so reflect the request headers
       headers.push([{
@@ -110,7 +104,6 @@
         value: allowedHeaders
       }]);
     }
-
     return headers;
   }
 


### PR DESCRIPTION
## Problem

When the `origin` option is set to a static string (e.g. `origin: 'https://example.com'`), the current code incorrectly sets `Vary: Origin` in the response:

```js
} else if (isString(options.origin)) {
  // fixed origin
  headers.push([{ key: 'Access-Control-Allow-Origin', value: options.origin }]);
  headers.push([{ key: 'Vary', value: 'Origin' }]); // <-- Bug: should NOT be here
}
```

This violates the [Fetch spec](https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches):

> If `Access-Control-Allow-Origin` is set to * or a static origin for a particular resource, then configure the server to always send `Access-Control-Allow-Origin` in responses for the resource — for non-CORS requests as well as CORS requests — and **do not use `Vary`**.

When `origin` is a static string, `Access-Control-Allow-Origin` is always the same value regardless of the request's `Origin` header. Setting `Vary: Origin` in this case unnecessarily inflates cache size — every unique client origin creates a separate cache entry even though the response is identical.

## Fix

Remove the `Vary: Origin` header from the `isString(options.origin)` branch of `configureOrigin()`. `Vary: Origin` is still correctly set for dynamic origin cases (RegExp, Array, function) where the response varies based on the request's `Origin` header.

## Testing

The existing test suite covers the static string origin case. A new test can verify `Vary: Origin` is NOT present in the response when `origin` is set to a static string.

Fixes #332