### PR TITLE
Fix: throw error when credentials=true with origin='*'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,13 @@
     return headers;
   }
 
+  function validateCredentialsAndOrigin(options) {
+    if (options.credentials === true && options.origin === '*') {
+      throw new Error('Cross-origin requests are not allowed when credentials are set to true with origin: "*". ' +
+        'See https://fetch.spec.whatwg.org/#cors-protocol-and-credentials');
+    }
+  }
+
   function configureMethods(options) {
     var methods = options.methods;
     if (methods.join) {
@@ -159,6 +166,8 @@
   function cors(options, req, res, next) {
     var headers = [],
       method = req.method && req.method.toUpperCase && req.method.toUpperCase();
+
+    validateCredentialsAndOrigin(options);
 
     if (method === 'OPTIONS') {
       // preflight

--- a/test/test.js
+++ b/test/test.js
@@ -729,3 +729,38 @@ FakeResponse.prototype.setHeader = function setHeader (name, value) {
   var key = name.toLowerCase()
   this._headers[key] = value
 }
+
+describe('credentials with origin "*"', function () {
+  it('throws an error when origin is "*" and credentials is true', function (done) {
+    var req = fakeRequest('GET');
+    var res = fakeResponse();
+    var next = function (err) {
+      if (err && err.message.indexOf('credentials') !== -1 && err.message.indexOf('origin') !== -1) {
+        done();
+      } else {
+        done(new Error('Expected error about credentials and origin, got: ' + (err ? err.message : 'no error')));
+      }
+    };
+
+    assert.throws(function () {
+      cors({ origin: '*', credentials: true })(req, res, next);
+    }, /Cross-origin requests are not allowed when credentials are set to true with origin/);
+    done();
+  });
+
+  it('allows origin "*" when credentials is false', function (done) {
+    var cb = after(1, done);
+    var req = fakeRequest('GET');
+    var res = new FakeResponse();
+
+    res.on('finish', function () {
+      assert.equal(res.getHeader('Access-Control-Allow-Origin'), '*');
+      assert.equal(res.getHeader('Access-Control-Allow-Credentials'), undefined);
+      cb();
+    });
+
+    cors({ origin: '*', credentials: false })(req, res, function (err) {
+      cb(err || new Error('should not be called'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

According to the CORS specification, using wildcard `*` in `Access-Control-Allow-Origin` header is forbidden when `Access-Control-Allow-Credentials` is set to `true`.

This fix adds validation that throws an error when both options are set, following the fetch spec: https://fetch.spec.whatwg.org/#cors-protocol-and-credentials

## Problem

Currently, the cors middleware allows setting `credentials: true` with `origin: '*'`, which violates the CORS standard and causes browsers to reject the request.

## Solution

Added a `validateCredentialsAndOrigin()` function that throws an error when both `credentials` is `true` and `origin` is `'*'`.

## Changes

- `lib/index.js`: Added `validateCredentialsAndOrigin()` function and call it in the cors middleware
- `test/test.js`: Added test cases for the new validation

## Testing

Added test cases:
- Verifies error is thrown when `credentials=true` and `origin='*'`
- Verifies `origin='*'` works normally when `credentials=false`

Fixes expressjs/cors#333