### PR TITLE
chore: drop object-assign

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,15 +2,7 @@
 
   'use strict';
 
-  var assign = require('object-assign');
   var vary = require('vary');
-
-  var defaults = {
-    origin: '*',
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-    preflightContinue: false,
-    optionsSuccessStatus: 204
-  };
 
   function isString(s) {
     return typeof s === 'string' || s instanceof String;
@@ -205,7 +197,21 @@
         if (err) {
           next(err);
         } else {
-          var corsOptions = assign({}, defaults, options);
+          // default options
+          var corsOptions = {
+            origin: '*',
+            methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+            preflightContinue: false,
+            optionsSuccessStatus: 204
+          };
+          options = Object(options);
+
+          for (var option in options) {
+            if (Object.prototype.hasOwnProperty.call(options, option)) {
+              corsOptions[option] = options[option];
+            };
+          };
+
           var originCallback = null;
           if (corsOptions.origin && typeof corsOptions.origin === 'function') {
             originCallback = corsOptions.origin;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "object-assign": "^4",
     "vary": "^1"
   },
   "devDependencies": {


### PR DESCRIPTION
We **ONLY** use `object-assign` to override the default options. Because We can't use `Object.assign` (native) for environment supports reason, I replace it with manual loop and override.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
