### PR TITLE
docs: replace ambiguous 'reflect' jargon in configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ app.listen(80, function () {
 ## Configuration Options
 
 * `origin`: Configures the **Access-Control-Allow-Origin** CORS header. Possible values:
-  - `Boolean` - set `origin` to `true` to reflect the [request origin](https://datatracker.ietf.org/doc/html/draft-abarth-origin-09), as defined by `req.header('Origin')`, or set it to `false` to disable CORS.
+  - `Boolean` - set `origin` to `true` to mirror the [request's origin](https://datatracker.ietf.org/doc/html/draft-abarth-origin-09), header back as the allowed origin, or set it to `false` to disable CORS.
   - `String` - set `origin` to a specific origin. For example, if you set it to
     - `"http://example.com"` only requests from "http://example.com" will be allowed.
     - `"*"` for all domains to be allowed. 
-  - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
+  - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be echoed back as the allowed origin. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
   - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
   - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback (called as `callback(err, origin)`, where `origin` is a non-function value of the `origin` option) as the second.
 * `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).


### PR DESCRIPTION
## What
Replaced the word "reflect" in the `origin` option description 
with clearer language that better explains the actual behavior.

## Why
Closes #384

The word "reflect" is jargon that confused users. The new wording 
clarifies that the request's Origin header is simply echoed back 
in the response.

## Changes
- Boolean option: "reflect the request origin" → "mirror the request's Origin header back"
- RegExp option: "will be reflected" → "will be echoed back as the allowed origin"