### PR TITLE
docs: warn against combining origin: true with credentials: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ app.listen(80, function () {
 * `preflightContinue`: Pass the CORS preflight response to the next handler.
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
 
+> [!WARNING]
+> **Avoid combining `origin: true` with `credentials: true`:** `origin: true` reflects whatever value is sent in the request's `Origin` header back as `Access-Control-Allow-Origin`, so it
+>  ends up authorizing *every* origin, not just one. Paired with `Access-Control-Allow-Credentials: true`, that means any website can make credentialed (cookie-bearing) requests to your API
+and read the response. If you need to support multiple specific origins with credentials, use an array, a `RegExp`, or a function for the `origin` option instead.
+
 The default configuration is the equivalent of:
 
 ```json


### PR DESCRIPTION
Adds a note near the configuration options warning that origin: true + credentials: true allows any origin to make credentialed requests, since origin: true reflects the request's Origin header rather than restricting it. Closes #422

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
