### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "test": "npm run lint && npm run test-ci",
     "test-ci": "nyc --reporter=lcov --reporter=text mocha --require test/support/env",
     "lint": "eslint lib test"
+  },
+  "homepage": "https://github.com/expressjs/cors",
+  "bugs": {
+    "url": "https://github.com/expressjs/cors/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.