### PR TITLE
fix: set Vary: Origin on all responses, even when Origin header is missing (#330)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -157,6 +157,10 @@
   }
 
   function cors(options, req, res, next) {
+    // Set Vary: Origin on all responses to prevent cache confusion
+    // when a subsequent CORS request arrives at the same URL.
+    vary(res, 'Origin');
+
     var headers = [],
       method = req.method && req.method.toUpperCase && req.method.toUpperCase();
 

--- a/test/test.js
+++ b/test/test.js
@@ -295,6 +295,24 @@ var util = require('util')
         cors(options)(req, res, next);
       });
 
+      it('sets Vary Origin even when Origin request header is missing', function (done) {
+        // arrange
+        var req, res, next, options;
+        options = {
+          origin: 'http://example.com'
+        };
+        req = fakeRequest('GET', {});  // no Origin header
+        res = fakeResponse();
+        next = function () {
+          // assert
+          assert.equal(res.getHeader('Vary'), 'Origin')
+          done();
+        };
+
+        // act
+        cors(options)(req, res, next);
+      });
+
       it('origin defaults to *', function (done) {
         // arrange
         var req, res, next;
@@ -442,7 +460,7 @@ var util = require('util')
 
         res.on('finish', function () {
           assert.strictEqual(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2')
-          assert.equal(res.getHeader('Vary'), undefined)
+          assert.equal(res.getHeader('Vary'), 'Origin')
           cb()
         })
 
@@ -458,7 +476,7 @@ var util = require('util')
 
         res.on('finish', function () {
           assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'header1,header2')
-          assert.equal(res.getHeader('Vary'), undefined)
+          assert.equal(res.getHeader('Vary'), 'Origin')
           cb()
         })
 
@@ -478,7 +496,7 @@ var util = require('util')
         next = function () {
           // assert
           assert.equal(res.getHeader('Access-Control-Allow-Headers'), undefined)
-          assert.equal(res.getHeader('Vary'), undefined)
+          assert.equal(res.getHeader('Vary'), 'Origin')
           done();
         };
 
@@ -493,7 +511,7 @@ var util = require('util')
 
         res.on('finish', function () {
           assert.equal(res.getHeader('Access-Control-Allow-Headers'), 'x-header-1, x-header-2')
-          assert.equal(res.getHeader('Vary'), 'Access-Control-Request-Headers')
+          assert.equal(res.getHeader('Vary'), 'Origin, Access-Control-Request-Headers')
           cb()
         })
 


### PR DESCRIPTION
When a request without an \Origin\ header arrives at a CORS-enabled endpoint, the \Vary: Origin\ response header was not set. This could cause caching proxies or CDNs to serve the non-CORS response to subsequent CORS requests (those that include an \Origin\ header), potentially blocking legitimate cross-origin usage.

This fix adds \ary(res, 'Origin')\ at the beginning of the \cors()\ function, ensuring the \Vary: Origin\ header is included on every response processed by the CORS middleware.

Fixes #330

**Changes:**
- \lib/index.js\: Call \ary(res, 'Origin')\ at start of \cors()\ to always include the header
- \	est/test.js\: Add test for missing Origin header case; update 4 existing tests that previously asserted Vary was undefined