### PR TITLE
fix: always set Vary: Origin in CORS middleware 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,6 +160,8 @@
     var headers = [],
       method = req.method && req.method.toUpperCase && req.method.toUpperCase();
 
+    vary(res, 'Origin');
+
     if (method === 'OPTIONS') {
       // preflight
       headers.push(configureOrigin(options, req));

--- a/test/test.js
+++ b/test/test.js
@@ -133,6 +133,15 @@ var util = require('util')
       cors()(req, res, next);
     });
 
+    it('always sets Vary: Origin header even when Origin request header is missing', function (done) {
+      var req = fakeRequest('GET');
+      var res = fakeResponse();
+      cors()(req, res, function () {
+        assert.strictEqual(res.getHeader('Vary'), 'Origin');
+        done();
+      });
+    });
+
     it('OPTION call with no options enables default CORS to all origins and methods', function (done) {
       var cb = after(1, done)
       var req = new FakeRequest('OPTIONS')


### PR DESCRIPTION
## Summary

Ensure the `Vary: Origin` response header is set on all responses processed by the CORS middleware, including requests where the `Origin` header is absent.

## Motivation

Without `Vary: Origin`, caching proxies or CDNs may cache a non-CORS response for requests without an `Origin` header and serve it to subsequent cross-origin requests, causing incorrect CORS behavior. Closes #330.

## Implementation

Invoke `vary(res, 'Origin')` unconditionally at the start of the `cors` middleware function in `lib/index.js`.

## Testing

Added a unit test in `test/test.js` asserting that `Vary: Origin` is set even when the request does not include an `Origin` header.