### PR TITLE
Remove the object-assign dependency (native Object.assign with an ES5 fallback)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,17 @@
 
   'use strict';
 
-  var assign = require('object-assign');
+  var assign = Object.assign || function (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+  };
   var vary = require('vary');
 
   var defaults = {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "object-assign": "^4",
     "vary": "^1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Removes the `object-assign` runtime dependency. `lib/index.js` now uses the native `Object.assign` when available (every Node.js >= 4), with a small inline fallback for the older runtimes this package still supports (`engines: node >= 0.10` — unchanged by this PR).

## Why

- `object-assign@4.1.1` has been frozen since 2017. Supply-chain audit tooling flags it as unmaintained, and the `cors -> object-assign` edge propagates that flag into every downstream dependency audit.
- On every Node.js >= 4, the package already resolves to the native `Object.assign` at require time — the dependency adds an install event and a maintainer surface without changing runtime behavior on any modern platform.
- One fewer package in the tree for every `cors` consumer.

## Compatibility

- `engines` is untouched (`node >= 0.10`).
- On ES2015+ runtimes (Node.js >= 4): native `Object.assign` — exactly what `object-assign@4.1.1` already delegated to.
- On ES5 runtimes (Node.js 0.10/0.12): the inline fallback copies own enumerable string-keyed properties, which is observably identical for this package's single call site (`assign({}, defaults, options)` on plain option objects). `for...in` over a `null`/`undefined` source is a no-op in ES5, matching native's ignore-null semantics. Symbol-keyed properties do not exist on those runtimes, so the native-vs-fallback difference is unobservable there.
- No public API change. The existing test suite covers the option-merging path.
